### PR TITLE
[Feature] Fully support inline edit for Postgres, MySQL, and SQLite3

### DIFF
--- a/core/graph/model/models_gen.go
+++ b/core/graph/model/models_gen.go
@@ -8,10 +8,6 @@ import (
 	"strconv"
 )
 
-type AuthResponse struct {
-	Status bool `json:"Status"`
-}
-
 type Column struct {
 	Type string `json:"Type"`
 	Name string `json:"Name"`
@@ -46,9 +42,18 @@ type Record struct {
 	Value string `json:"Value"`
 }
 
+type RecordInput struct {
+	Key   string `json:"Key"`
+	Value string `json:"Value"`
+}
+
 type RowsResult struct {
 	Columns []*Column  `json:"Columns"`
 	Rows    [][]string `json:"Rows"`
+}
+
+type StatusResponse struct {
+	Status bool `json:"Status"`
 }
 
 type StorageUnit struct {

--- a/core/graph/schema.graphqls
+++ b/core/graph/schema.graphqls
@@ -23,6 +23,11 @@ type Record {
   Value: String!
 }
 
+input RecordInput {
+  Key: String!
+  Value: String!
+}
+
 type StorageUnit {
   Name: String!
   Attributes: [Record!]!
@@ -54,9 +59,10 @@ input LoginCredentials {
   Database: String!
 }
 
-type AuthResponse {
+type StatusResponse {
   Status: Boolean!
 }
+
 
 type Query {
   Database(type: DatabaseType!): [String!]!
@@ -68,8 +74,8 @@ type Query {
 }
 
 type Mutation {
-  Login(credentails: LoginCredentials!): AuthResponse!
-  Logout: AuthResponse!
+  Login(credentails: LoginCredentials!): StatusResponse!
+  Logout: StatusResponse!
 
-  CreateStorageUnit(type: DatabaseType!): StorageUnit!
+  UpdateStorageUnit(type: DatabaseType!, schema: String!, storageUnit: String!, values: [RecordInput!]!): StatusResponse!
 }

--- a/core/graph/schema.resolvers.go
+++ b/core/graph/schema.resolvers.go
@@ -7,7 +7,6 @@ package graph
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/clidey/whodb/core/graph/model"
 	"github.com/clidey/whodb/core/src"
@@ -16,7 +15,7 @@ import (
 )
 
 // Login is the resolver for the Login field.
-func (r *mutationResolver) Login(ctx context.Context, credentails model.LoginCredentials) (*model.AuthResponse, error) {
+func (r *mutationResolver) Login(ctx context.Context, credentails model.LoginCredentials) (*model.StatusResponse, error) {
 	if !src.MainEngine.Choose(engine.DatabaseType(credentails.Type)).IsAvailable(&engine.PluginConfig{
 		Credentials: &engine.Credentials{
 			Hostname: credentails.Hostname,
@@ -31,13 +30,24 @@ func (r *mutationResolver) Login(ctx context.Context, credentails model.LoginCre
 }
 
 // Logout is the resolver for the Logout field.
-func (r *mutationResolver) Logout(ctx context.Context) (*model.AuthResponse, error) {
+func (r *mutationResolver) Logout(ctx context.Context) (*model.StatusResponse, error) {
 	return auth.Logout(ctx)
 }
 
-// CreateStorageUnit is the resolver for the CreateStorageUnit field.
-func (r *mutationResolver) CreateStorageUnit(ctx context.Context, typeArg model.DatabaseType) (*model.StorageUnit, error) {
-	panic(fmt.Errorf("not implemented: Schema - Schema"))
+// UpdateStorageUnit is the resolver for the UpdateStorageUnit field.
+func (r *mutationResolver) UpdateStorageUnit(ctx context.Context, typeArg model.DatabaseType, schema string, storageUnit string, values []*model.RecordInput) (*model.StatusResponse, error) {
+	config := engine.NewPluginConfig(auth.GetCredentials(ctx))
+	valuesMap := map[string]string{}
+	for _, value := range values {
+		valuesMap[value.Key] = value.Value
+	}
+	status, err := src.MainEngine.Choose(engine.DatabaseType(typeArg)).UpdateStorageUnit(config, schema, storageUnit, valuesMap)
+	if err != nil {
+		return nil, err
+	}
+	return &model.StatusResponse{
+		Status: status,
+	}, nil
 }
 
 // Database is the resolver for the Database field.

--- a/core/src/auth/login.go
+++ b/core/src/auth/login.go
@@ -11,7 +11,7 @@ import (
 	"github.com/clidey/whodb/core/src/common"
 )
 
-func Login(ctx context.Context, input *model.LoginCredentials) (*model.AuthResponse, error) {
+func Login(ctx context.Context, input *model.LoginCredentials) (*model.StatusResponse, error) {
 	loginInfoJSON, err := json.Marshal(input)
 	if err != nil {
 		return nil, err
@@ -29,7 +29,7 @@ func Login(ctx context.Context, input *model.LoginCredentials) (*model.AuthRespo
 
 	http.SetCookie(ctx.Value(common.RouterKey_ResponseWriter).(http.ResponseWriter), cookie)
 
-	return &model.AuthResponse{
+	return &model.StatusResponse{
 		Status: true,
 	}, nil
 }

--- a/core/src/auth/logout.go
+++ b/core/src/auth/logout.go
@@ -8,9 +8,9 @@ import (
 	"github.com/clidey/whodb/core/src/common"
 )
 
-func Logout(ctx context.Context) (*model.AuthResponse, error) {
+func Logout(ctx context.Context) (*model.StatusResponse, error) {
 	http.SetCookie(ctx.Value(common.RouterKey_ResponseWriter).(http.ResponseWriter), nil)
-	return &model.AuthResponse{
+	return &model.StatusResponse{
 		Status: true,
 	}, nil
 }

--- a/core/src/common/utils.go
+++ b/core/src/common/utils.go
@@ -1,0 +1,10 @@
+package common
+
+func ContainsString(slice []string, element string) bool {
+	for _, item := range slice {
+		if item == element {
+			return true
+		}
+	}
+	return false
+}

--- a/core/src/engine/plugin.go
+++ b/core/src/engine/plugin.go
@@ -56,6 +56,7 @@ type PluginFunctions interface {
 	IsAvailable(config *PluginConfig) bool
 	GetSchema(config *PluginConfig) ([]string, error)
 	GetStorageUnits(config *PluginConfig, schema string) ([]StorageUnit, error)
+	UpdateStorageUnit(config *PluginConfig, schema string, storageUnit string, values map[string]string) (bool, error)
 	GetRows(config *PluginConfig, schema string, storageUnit string, where string, pageSize int, pageOffset int) (*GetRowsResult, error)
 	GetGraph(config *PluginConfig, schema string) ([]GraphUnit, error)
 	RawExecute(config *PluginConfig, query string) (*GetRowsResult, error)

--- a/core/src/plugins/mysql/update.go
+++ b/core/src/plugins/mysql/update.go
@@ -1,0 +1,148 @@
+package mysql
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/clidey/whodb/core/src/common"
+	"github.com/clidey/whodb/core/src/engine"
+	"gorm.io/gorm"
+)
+
+func (p *MySQLPlugin) UpdateStorageUnit(config *engine.PluginConfig, schema string, storageUnit string, values map[string]string) (bool, error) {
+	db, err := DB(config)
+	if err != nil {
+		return false, err
+	}
+
+	sqlDb, err := db.DB()
+	if err != nil {
+		return false, err
+	}
+	defer sqlDb.Close()
+
+	pkColumns, err := getPrimaryKeyColumns(db, schema, storageUnit)
+	if err != nil {
+		return false, err
+	}
+
+	columnTypes, err := getColumnTypes(db, schema, storageUnit)
+	if err != nil {
+		return false, err
+	}
+
+	conditions := make(map[string]interface{})
+	convertedValues := make(map[string]interface{})
+	for column, strValue := range values {
+		columnType, exists := columnTypes[column]
+		if !exists {
+			return false, fmt.Errorf("column '%s' does not exist in table %s", column, storageUnit)
+		}
+
+		convertedValue, err := convertStringValue(strValue, columnType)
+		if err != nil {
+			return false, fmt.Errorf("failed to convert value for column '%s': %v", column, err)
+		}
+
+		if common.ContainsString(pkColumns, column) {
+			conditions[column] = convertedValue
+		} else {
+			convertedValues[column] = convertedValue
+		}
+	}
+
+	tableName := fmt.Sprintf("%s.%s", schema, storageUnit)
+	dbConditions := db.Table(tableName)
+	for key, value := range conditions {
+		dbConditions = dbConditions.Where(fmt.Sprintf("%s = ?", key), value)
+	}
+
+	result := dbConditions.Table(tableName).Updates(convertedValues)
+	if result.Error != nil {
+		return false, result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return false, errors.New("no rows were updated")
+	}
+
+	return true, nil
+}
+
+func getPrimaryKeyColumns(db *gorm.DB, schema string, tableName string) ([]string, error) {
+	var primaryKeys []string
+	query := `
+		SELECT k.column_name
+		FROM information_schema.table_constraints t
+		JOIN information_schema.key_column_usage k
+		USING (constraint_name, table_schema, table_name)
+		WHERE t.constraint_type = 'PRIMARY KEY'
+		AND t.table_schema = ?
+		AND t.table_name = ?;
+	`
+	rows, err := db.Raw(query, schema, tableName).Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var pkColumn string
+		if err := rows.Scan(&pkColumn); err != nil {
+			return nil, err
+		}
+		primaryKeys = append(primaryKeys, pkColumn)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if len(primaryKeys) == 0 {
+		return nil, fmt.Errorf("no primary key found for table %s", tableName)
+	}
+
+	return primaryKeys, nil
+}
+
+func getColumnTypes(db *gorm.DB, schema, tableName string) (map[string]string, error) {
+	columnTypes := make(map[string]string)
+	query := `
+		SELECT column_name, data_type
+		FROM information_schema.columns
+		WHERE table_schema = ? AND table_name = ?;
+	`
+	rows, err := db.Raw(query, schema, tableName).Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var columnName, dataType string
+		if err := rows.Scan(&columnName, &dataType); err != nil {
+			return nil, err
+		}
+		columnTypes[columnName] = dataType
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return columnTypes, nil
+}
+
+func convertStringValue(value, columnType string) (interface{}, error) {
+	switch columnType {
+	case "int", "bigint", "smallint", "tinyint", "mediumint":
+		return strconv.Atoi(value)
+	case "boolean", "bit":
+		return strconv.ParseBool(value)
+	case "float", "double", "decimal":
+		return strconv.ParseFloat(value, 64)
+	default:
+		return value, nil
+	}
+}

--- a/core/src/plugins/postgres/update.go
+++ b/core/src/plugins/postgres/update.go
@@ -1,0 +1,167 @@
+package postgres
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/clidey/whodb/core/src/common"
+	"github.com/clidey/whodb/core/src/engine"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+func (p *PostgresPlugin) UpdateStorageUnit(config *engine.PluginConfig, schema string, storageUnit string, values map[string]string) (bool, error) {
+	db, err := DB(config)
+	if err != nil {
+		return false, err
+	}
+
+	sqlDb, err := db.DB()
+	if err != nil {
+		return false, err
+	}
+	defer sqlDb.Close()
+
+	pkColumns, err := getPrimaryKeyColumns(db, schema, storageUnit)
+	if err != nil {
+		return false, err
+	}
+
+	columnTypes, err := getColumnTypes(db, schema, storageUnit)
+	if err != nil {
+		return false, err
+	}
+
+	conditions := make(map[string]interface{})
+	convertedValues := make(map[string]interface{})
+	for column, strValue := range values {
+		columnType, exists := columnTypes[column]
+		if !exists {
+			return false, fmt.Errorf("column '%s' does not exist in table %s", column, storageUnit)
+		}
+
+		convertedValue, err := convertStringValue(strValue, columnType)
+		if err != nil {
+			return false, fmt.Errorf("failed to convert value for column '%s': %v", column, err)
+		}
+
+		if common.ContainsString(pkColumns, column) {
+			conditions[column] = convertedValue
+		} else {
+			convertedValues[column] = convertedValue
+		}
+	}
+
+	tableName := fmt.Sprintf("%s.%s", schema, storageUnit)
+	dbConditions := db.Table(tableName)
+	for key, value := range conditions {
+		dbConditions = dbConditions.Where(fmt.Sprintf("%s = ?", key), value)
+	}
+
+	result := dbConditions.Table(tableName).Updates(convertedValues)
+	if result.Error != nil {
+		return false, result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return false, errors.New("no rows were updated")
+	}
+
+	return true, nil
+}
+
+func getPrimaryKeyColumns(db *gorm.DB, schema string, tableName string) ([]string, error) {
+	var primaryKeys []string
+	query := `
+		SELECT a.attname
+		FROM pg_index i
+		JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+		JOIN pg_class c ON c.oid = i.indrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = ? AND c.relname = ? AND i.indisprimary;
+	`
+	rows, err := db.Raw(query, schema, tableName).Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var pkColumn string
+		if err := rows.Scan(&pkColumn); err != nil {
+			return nil, err
+		}
+		primaryKeys = append(primaryKeys, pkColumn)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if len(primaryKeys) == 0 {
+		return nil, fmt.Errorf("no primary key found for table %s", tableName)
+	}
+
+	return primaryKeys, nil
+}
+
+func getColumnTypes(db *gorm.DB, schema, tableName string) (map[string]string, error) {
+	columnTypes := make(map[string]string)
+	query := `
+		SELECT column_name, data_type
+		FROM information_schema.columns
+		WHERE table_schema = ? AND table_name = ?;
+	`
+	rows, err := db.Raw(query, schema, tableName).Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var columnName, dataType string
+		if err := rows.Scan(&columnName, &dataType); err != nil {
+			return nil, err
+		}
+		columnTypes[columnName] = dataType
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return columnTypes, nil
+}
+
+func convertStringValue(value, columnType string) (interface{}, error) {
+	switch columnType {
+	case "integer", "smallint", "bigint":
+		return strconv.ParseInt(value, 10, 64)
+	case "numeric", "real", "double precision":
+		return strconv.ParseFloat(value, 64)
+	case "boolean":
+		return strconv.ParseBool(value)
+	case "uuid":
+		_, err := uuid.Parse(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid UUID format: %v", err)
+		}
+		return value, nil
+	case "date":
+		_, err := time.Parse("2006-01-02", value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid date format: %v", err)
+		}
+		return value, nil
+	case "timestamp", "timestamp with time zone", "timestamp without time zone":
+		_, err := time.Parse(time.RFC3339, value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid timestamp format: %v", err)
+		}
+		return value, nil
+	default:
+		return value, nil
+	}
+}

--- a/core/src/plugins/sqlite3/update.go
+++ b/core/src/plugins/sqlite3/update.go
@@ -1,0 +1,130 @@
+package sqlite3
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/clidey/whodb/core/src/common"
+	"github.com/clidey/whodb/core/src/engine"
+	"gorm.io/gorm"
+)
+
+func (p *Sqlite3Plugin) UpdateStorageUnit(config *engine.PluginConfig, schema string, storageUnit string, values map[string]string) (bool, error) {
+	db, err := DB(config)
+	if err != nil {
+		return false, err
+	}
+
+	sqlDb, err := db.DB()
+	if err != nil {
+		return false, err
+	}
+	defer sqlDb.Close()
+
+	pkColumns, columnTypes, err := getTableInfo(db, storageUnit)
+	if err != nil {
+		return false, err
+	}
+
+	conditions := make(map[string]interface{})
+	convertedValues := make(map[string]interface{})
+	for column, strValue := range values {
+		columnType, exists := columnTypes[column]
+		if !exists {
+			return false, fmt.Errorf("column '%s' does not exist in table %s", column, storageUnit)
+		}
+
+		convertedValue, err := convertStringValue(strValue, columnType)
+		if err != nil {
+			return false, fmt.Errorf("failed to convert value for column '%s': %v", column, err)
+		}
+
+		if common.ContainsString(pkColumns, column) {
+			conditions[column] = convertedValue
+		} else {
+			convertedValues[column] = convertedValue
+		}
+	}
+
+	dbConditions := db.Table(storageUnit)
+	for key, value := range conditions {
+		dbConditions = dbConditions.Where(fmt.Sprintf("%s = ?", key), value)
+	}
+
+	result := dbConditions.Table(storageUnit).Updates(convertedValues)
+	if result.Error != nil {
+		return false, result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return false, errors.New("no rows were updated")
+	}
+
+	return true, nil
+}
+
+func getTableInfo(db *gorm.DB, tableName string) ([]string, map[string]string, error) {
+	var primaryKeys []string
+	columnTypes := make(map[string]string)
+	pragmaQuery := fmt.Sprintf("PRAGMA table_info(%s)", tableName)
+	rows, err := db.Raw(pragmaQuery, tableName).Rows()
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			cid       int
+			name      string
+			type_     string
+			notnull   int
+			dfltValue interface{}
+			pk        int
+		)
+		if err := rows.Scan(&cid, &name, &type_, &notnull, &dfltValue, &pk); err != nil {
+			return nil, nil, err
+		}
+		columnTypes[name] = type_
+		if pk == 1 {
+			primaryKeys = append(primaryKeys, name)
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	if len(primaryKeys) == 0 {
+		return nil, nil, fmt.Errorf("no primary key found for table %s", tableName)
+	}
+
+	return primaryKeys, columnTypes, nil
+}
+
+func convertStringValue(value, columnType string) (interface{}, error) {
+	switch columnType {
+	case "INTEGER":
+		return strconv.ParseInt(value, 10, 64)
+	case "REAL":
+		return strconv.ParseFloat(value, 64)
+	case "BOOLEAN":
+		return strconv.ParseBool(value)
+	case "DATE":
+		_, err := time.Parse("2006-01-02", value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid date format: %v", err)
+		}
+		return value, nil
+	case "DATETIME":
+		_, err := time.Parse(time.RFC3339, value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid datetime format: %v", err)
+		}
+		return value, nil
+	default:
+		return value, nil
+	}
+}

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -17,11 +17,6 @@ export type Scalars = {
   Float: { input: number; output: number; }
 };
 
-export type AuthResponse = {
-  __typename?: 'AuthResponse';
-  Status: Scalars['Boolean']['output'];
-};
-
 export type Column = {
   __typename?: 'Column';
   Name: Scalars['String']['output'];
@@ -64,19 +59,22 @@ export type LoginCredentials = {
 
 export type Mutation = {
   __typename?: 'Mutation';
-  CreateStorageUnit: StorageUnit;
-  Login: AuthResponse;
-  Logout: AuthResponse;
-};
-
-
-export type MutationCreateStorageUnitArgs = {
-  type: DatabaseType;
+  Login: StatusResponse;
+  Logout: StatusResponse;
+  UpdateStorageUnit: StatusResponse;
 };
 
 
 export type MutationLoginArgs = {
   credentails: LoginCredentials;
+};
+
+
+export type MutationUpdateStorageUnitArgs = {
+  schema: Scalars['String']['input'];
+  storageUnit: Scalars['String']['input'];
+  type: DatabaseType;
+  values: Array<RecordInput>;
 };
 
 export type Query = {
@@ -133,10 +131,20 @@ export type Record = {
   Value: Scalars['String']['output'];
 };
 
+export type RecordInput = {
+  Key: Scalars['String']['input'];
+  Value: Scalars['String']['input'];
+};
+
 export type RowsResult = {
   __typename?: 'RowsResult';
   Columns: Array<Column>;
   Rows: Array<Array<Scalars['String']['output']>>;
+};
+
+export type StatusResponse = {
+  __typename?: 'StatusResponse';
+  Status: Scalars['Boolean']['output'];
 };
 
 export type StorageUnit = {
@@ -164,12 +172,12 @@ export type LoginMutationVariables = Exact<{
 }>;
 
 
-export type LoginMutation = { __typename?: 'Mutation', Login: { __typename?: 'AuthResponse', Status: boolean } };
+export type LoginMutation = { __typename?: 'Mutation', Login: { __typename?: 'StatusResponse', Status: boolean } };
 
 export type LogoutMutationVariables = Exact<{ [key: string]: never; }>;
 
 
-export type LogoutMutation = { __typename?: 'Mutation', Logout: { __typename?: 'AuthResponse', Status: boolean } };
+export type LogoutMutation = { __typename?: 'Mutation', Logout: { __typename?: 'StatusResponse', Status: boolean } };
 
 export type GetGraphQueryVariables = Exact<{
   type: DatabaseType;
@@ -206,6 +214,16 @@ export type GetStorageUnitsQueryVariables = Exact<{
 
 
 export type GetStorageUnitsQuery = { __typename?: 'Query', StorageUnit: Array<{ __typename?: 'StorageUnit', Name: string, Attributes: Array<{ __typename?: 'Record', Key: string, Value: string }> }> };
+
+export type UpdateStorageUnitMutationVariables = Exact<{
+  type: DatabaseType;
+  schema: Scalars['String']['input'];
+  storageUnit: Scalars['String']['input'];
+  values: Array<RecordInput> | RecordInput;
+}>;
+
+
+export type UpdateStorageUnitMutation = { __typename?: 'Mutation', UpdateStorageUnit: { __typename?: 'StatusResponse', Status: boolean } };
 
 
 export const GetSchemaDocument = gql`
@@ -546,3 +564,44 @@ export type GetStorageUnitsQueryHookResult = ReturnType<typeof useGetStorageUnit
 export type GetStorageUnitsLazyQueryHookResult = ReturnType<typeof useGetStorageUnitsLazyQuery>;
 export type GetStorageUnitsSuspenseQueryHookResult = ReturnType<typeof useGetStorageUnitsSuspenseQuery>;
 export type GetStorageUnitsQueryResult = Apollo.QueryResult<GetStorageUnitsQuery, GetStorageUnitsQueryVariables>;
+export const UpdateStorageUnitDocument = gql`
+    mutation UpdateStorageUnit($type: DatabaseType!, $schema: String!, $storageUnit: String!, $values: [RecordInput!]!) {
+  UpdateStorageUnit(
+    type: $type
+    schema: $schema
+    storageUnit: $storageUnit
+    values: $values
+  ) {
+    Status
+  }
+}
+    `;
+export type UpdateStorageUnitMutationFn = Apollo.MutationFunction<UpdateStorageUnitMutation, UpdateStorageUnitMutationVariables>;
+
+/**
+ * __useUpdateStorageUnitMutation__
+ *
+ * To run a mutation, you first call `useUpdateStorageUnitMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateStorageUnitMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateStorageUnitMutation, { data, loading, error }] = useUpdateStorageUnitMutation({
+ *   variables: {
+ *      type: // value for 'type'
+ *      schema: // value for 'schema'
+ *      storageUnit: // value for 'storageUnit'
+ *      values: // value for 'values'
+ *   },
+ * });
+ */
+export function useUpdateStorageUnitMutation(baseOptions?: Apollo.MutationHookOptions<UpdateStorageUnitMutation, UpdateStorageUnitMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateStorageUnitMutation, UpdateStorageUnitMutationVariables>(UpdateStorageUnitDocument, options);
+      }
+export type UpdateStorageUnitMutationHookResult = ReturnType<typeof useUpdateStorageUnitMutation>;
+export type UpdateStorageUnitMutationResult = Apollo.MutationResult<UpdateStorageUnitMutation>;
+export type UpdateStorageUnitMutationOptions = Apollo.BaseMutationOptions<UpdateStorageUnitMutation, UpdateStorageUnitMutationVariables>;

--- a/frontend/src/pages/storage-unit/update-storage-unit.graphql
+++ b/frontend/src/pages/storage-unit/update-storage-unit.graphql
@@ -1,0 +1,5 @@
+mutation UpdateStorageUnit($type: DatabaseType!, $schema: String!, $storageUnit:String!, $values: [RecordInput!]!) {
+  UpdateStorageUnit(type: $type, schema: $schema, storageUnit: $storageUnit, values: $values) {
+    Status
+  }
+}


### PR DESCRIPTION
- [core] Add inline edit support for Postgres, MySQL, SQLite3
- - Use the primary key automatically to update (should support composite keys)
- - Add sanitization logic to ensure that types are received in the correct format
- [frontend] Fix edit to be padded for easily clickable
- [frontend] Make the table in edit performant by making a async query and not updating the component
- [frontend] Enable hidden button