### PR TITLE
[Support] UI based filters

### DIFF
--- a/core/src/plugins/elasticsearch/elasticsearch.go
+++ b/core/src/plugins/elasticsearch/elasticsearch.go
@@ -132,12 +132,10 @@ func (p *ElasticSearchPlugin) GetRows(config *engine.PluginConfig, database, col
 
 	for _, hit := range hits {
 		hitMap := hit.(map[string]interface{})
-		source := hitMap["_source"]
+		source := hitMap["_source"].(map[string]interface{})
 		id := hitMap["_id"]
-		document := map[string]interface{}{}
-		document["_id"] = id
-		document["source"] = source
-		jsonBytes, err := json.Marshal(document)
+		source["_id"] = id
+		jsonBytes, err := json.Marshal(source)
 		if err != nil {
 			return nil, err
 		}

--- a/core/src/plugins/mongodb/mongodb.go
+++ b/core/src/plugins/mongodb/mongodb.go
@@ -71,6 +71,7 @@ func (p *MongoDBPlugin) GetStorageUnits(config *engine.PluginConfig, database st
 	}
 	return storageUnits, nil
 }
+
 func (p *MongoDBPlugin) GetRows(config *engine.PluginConfig, database, collection, filter string, pageSize, pageOffset int) (*engine.GetRowsResult, error) {
 	client, err := DB(config)
 	if err != nil {

--- a/frontend/src/components/breadcrumbs.tsx
+++ b/frontend/src/components/breadcrumbs.tsx
@@ -3,6 +3,8 @@ import { FC, cloneElement } from "react";
 import { useNavigate } from "react-router-dom";
 import { IInternalRoute } from "../config/routes";
 import { Icons } from "./icons";
+import { BRAND_COLOR } from "./classes";
+import { twMerge } from "tailwind-merge";
 
 export type IBreadcrumbRoute = Omit<IInternalRoute, "component">;
 
@@ -21,15 +23,15 @@ export const Breadcrumb: FC<IBreadcrumbProps> = ({ routes, active }) => {
                         <li key={route.name}>
                             <div className="flex items-center transition-all gap-2 hover:gap-3 group/breadcrumb dark:text-neutral-300">
                                 {i > 0 && Icons.RightChevron}
-                                <div onClick={() => handleNavigate(route.path)} className={classNames("cursor-pointer text-sm font-medium text-gray-700 hover:text-teal-500 flex items-center gap-2 hover:gap-3 transition-all dark:text-neutral-300", {
-                                    "text-teal-800 dark:text-teal-500": active === route,
-                                })}>
+                                <div onClick={() => handleNavigate(route.path)} className={twMerge(classNames("cursor-pointer text-sm font-medium text-neutral-800 hover:text-[#ca6f1e] flex items-center gap-2 hover:gap-3 transition-all dark:text-neutral-300", {
+                                    [BRAND_COLOR]: active === route,
+                                }))}>
                                     {
                                         i === 0 &&
                                         <div className="inline-flex items-center text-sm font-medium text-gray-700 dark:text-neutral-300">
                                             {cloneElement(Icons.Home, {
-                                                className: classNames("w-3 h-3 group-hover/breadcrumb:fill-teal-500", {
-                                                        "fill-teal-800 dark:fill-teal-500": active === route,
+                                                className: classNames("w-3 h-3 group-hover/breadcrumb:fill-[#ca6f1e]", {
+                                                        "fill-[#ca6f1e] dark:fill-[#ca6f1e]": active === route,
                                                     })
                                                 })
                                             }

--- a/frontend/src/components/classes.ts
+++ b/frontend/src/components/classes.ts
@@ -1,2 +1,2 @@
 export const BASE_CARD_CLASS = "bg-white h-[200px] w-[200px] rounded-3xl shadow-sm border p-4 flex flex-col justify-between dark:bg-white/10 dark:border-white/5";
-export const BRAND_COLOR = "text-[#ca6f1e]";
+export const BRAND_COLOR = "text-[#ca6f1e] dark:text-[#ca6f1e]";

--- a/frontend/src/components/dropdown.tsx
+++ b/frontend/src/components/dropdown.tsx
@@ -4,6 +4,14 @@ import { Icons } from "./icons";
 import { Label } from "./input";
 import { Loading } from "./loading";
 
+export function createDropdownItem(option: string, icon?: ReactElement): IDropdownItem {
+    return {
+        id: option,
+        label: option,
+        icon,
+    };
+}
+
 export type IDropdownItem<T extends unknown = any> = {
     id: string;
     label: string;
@@ -86,7 +94,7 @@ export const Dropdown: FC<IDropdownProps> = (props) => {
                         }
                         {
                             props.items.length === 0 && props.defaultItem == null &&
-                            <li className="flex items-center gap-1 px-2" onClick={props.onDefaultItemClick}>
+                            <li className="flex items-center gap-1 px-2 dark:text-neutral-300" onClick={props.onDefaultItemClick}>
                                 <div>{Icons.SadSmile}</div>
                                 <div>{props.noItemsLabel}</div>
                             </li>

--- a/frontend/src/components/input.tsx
+++ b/frontend/src/components/input.tsx
@@ -31,7 +31,7 @@ export const Input: FC<InputProps> = ({ value, setValue, type, placeholder, inpu
     }, [inputProps]);
     
     return <input type={type} placeholder={placeholder}
-        value={value}  {...inputProps} onChange={handleChange} onKeyDown={handleKeyDown}
+        {...inputProps} onChange={handleChange} onKeyDown={handleKeyDown} value={value}
         className={twMerge(classNames("appearance-none border border-gray-200 rounded-md w-full p-1 text-gray-700 leading-tight focus:outline-none focus:shadow-outline text-sm h-[34px] px-2 dark:text-neutral-300/100 dark:bg-white/10 dark:border-white/20", inputProps.className))} />
 }
 

--- a/frontend/src/components/sidebar/sidebar.tsx
+++ b/frontend/src/components/sidebar/sidebar.tsx
@@ -231,7 +231,7 @@ export const Sidebar: FC = () => {
             onError(error) {
                 notify(`Error signing you in: ${error.message}`, "error")
             },
-        })
+        });
     }, [dispatch, login, navigate, profiles]);
 
     const handleNavigateToLogin = useCallback(() => {

--- a/frontend/src/components/table.tsx
+++ b/frontend/src/components/table.tsx
@@ -409,7 +409,7 @@ export const Table: FC<ITableProps> = ({ className, columns: actualColumns, rows
     }, [rows]);
 
     const handleKeyUp = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
-        if (tableRef.current == null) {
+        if (tableRef.current == null || search.length === 0) {
             return;
         }
         let interval: NodeJS.Timeout;

--- a/frontend/src/components/table.tsx
+++ b/frontend/src/components/table.tsx
@@ -12,7 +12,7 @@ import { useExportToCSV, useLongPress } from "./hooks";
 import { Icons } from "./icons";
 import { SearchInput } from "./search";
 import { Loading } from "./loading";
-import { clone } from "lodash";
+import { clone, values } from "lodash";
 
 type IPaginationProps = {
     pageCount: number;
@@ -183,7 +183,7 @@ const TData: FC<ITDataProps> = ({ cell, onCellUpdate, disableEdit }) => {
             "bg-gray-200 dark:bg-white/10 blur-[2px]": editable || preview,
         })}
     >
-        <span className="hidden">{editedData}</span>
+        <span className="cell-data hidden">{editedData}</span>
         <div 
             className={classNames("w-full h-full p-2 leading-tight focus:outline-none focus:shadow-outline appearance-none transition-all duration-300 border-solid border-gray-200 dark:border-white/5 overflow-hidden whitespace-nowrap select-none text-gray-600 dark:text-neutral-300", {
                 "group-even/row:bg-gray-100 hover:bg-gray-300 group-even/row:hover:bg-gray-300 dark:group-even/row:bg-white/10 dark:group-odd/row:bg-white/5 dark:group-even/row:hover:bg-white/15 dark:group-odd/row:hover:bg-white/15": !editable,
@@ -305,7 +305,7 @@ const TableRow: FC<ITableRow> = ({ row, style, onRowUpdate, disableEdit }) => {
         <div className="table-row-group text-xs group/row" {...props} key={props.key}>
             {
                 row.cells.map((cell) => (
-                    <TData key={cell.getCellProps().key} cell={cell} onCellUpdate={handleCellUpdate} disableEdit={disableEdit} />
+                    <TData key={cell.getCellProps().key} cell={cell} onCellUpdate={handleCellUpdate} disableEdit={disableEdit || cell.column.id === "#"} />
                 ))
             }
         </div>
@@ -325,6 +325,7 @@ type ITableProps = {
 }
 
 export const Table: FC<ITableProps> = ({ className, columns: actualColumns, rows: actualRows, columnTags, totalPages, currentPage, onPageChange, onRowUpdate, disableEdit }) => {
+    const fixedTableRef = useRef<FixedSizeList>(null);
     const containerRef = useRef<HTMLDivElement>(null);
     const operationsRef = useRef<HTMLDivElement>(null);
     const tableRef = useRef<HTMLTableElement>(null);
@@ -413,38 +414,38 @@ export const Table: FC<ITableProps> = ({ className, columns: actualColumns, rows
         }
         let interval: NodeJS.Timeout;
         if (e.key === "Enter") {
-            let newSearchIndex = (searchIndex + 1) % rowCount;
-            setSearchIndex(newSearchIndex);
             const searchText = search.toLowerCase();
-            let index = 0;
-            const tbody = tableRef.current.querySelector(".tbody");
-            if (tbody == null) {
-                return;
-            }
-            for (const childNode of tbody.childNodes) {
-                if (childNode instanceof HTMLTableRowElement) {
-                    const text = childNode.textContent?.toLowerCase();
+            const filteredToOriginalIndex = [];
+            for (const [index, row] of rows.entries()) {
+                for (const value of values(row.values)) {
+                    const text = value.toLowerCase();
                     if (text != null && searchText != null && text.includes(searchText)) {
-                        if (index === newSearchIndex) {
-                            childNode.scrollIntoView({
-                                behavior: "smooth",
-                                block: "center",
-                                inline: "center",
-                            });
-                            for (const cell of childNode.querySelectorAll("input")) {
-                                if (cell instanceof HTMLInputElement) {
-                                    cell.classList.add("!bg-yellow-100");
-                                    interval = setTimeout(() => {
-                                        cell.classList.remove("!bg-yellow-100");
-                                    }, 3000);
-                                }
-                            }
-                            return;
-                        }
-                        index++;
+                        filteredToOriginalIndex.push(index);
                     }
                 }
-            };
+            }
+            
+            if (rows.length > 0 &&  filteredToOriginalIndex.length > 0) {
+                const newSearchIndex = (searchIndex + 1) % filteredToOriginalIndex.length;
+                setSearchIndex(newSearchIndex);
+                const originalIndex = filteredToOriginalIndex[newSearchIndex] + 1;
+                fixedTableRef.current?.scrollToItem(originalIndex, "center");
+                setTimeout(() => {
+                    const currentVisibleRows = tableRef.current?.querySelectorAll(".table-row-group") ?? [];
+                    for (const currentVisibleRow of currentVisibleRows) {
+                        const text = currentVisibleRow.querySelector("div > span")?.textContent ?? "";
+                        if (isNumeric(text)) {
+                            const id = parseInt(text);
+                            if (id === originalIndex) {
+                                currentVisibleRow.classList.add("!bg-yellow-100", "dark:!bg-yellow-800");
+                                interval = setTimeout(() => {
+                                    currentVisibleRow.classList.remove("!bg-yellow-100", "dark:!bg-yellow-800");
+                                }, 3000);
+                            }
+                        }
+                    }
+                }, 100);
+            }
         }
 
         return () => {
@@ -452,7 +453,7 @@ export const Table: FC<ITableProps> = ({ className, columns: actualColumns, rows
                 clearInterval(interval);
             }
         }
-    }, [search, rowCount, searchIndex]);
+    }, [rows, search, searchIndex]);
 
     const handleSearchChange = useCallback((newValue: string) => {
         setSearchIndex(-1);
@@ -541,6 +542,7 @@ export const Table: FC<ITableProps> = ({ className, columns: actualColumns, rows
                     </div>
                     <div className="tbody" {...getTableBodyProps()}>
                         <FixedSizeList
+                            ref={fixedTableRef}
                             height={height}
                             itemCount={sortedRows.length}
                             itemSize={31}

--- a/frontend/src/pages/raw-execute/raw-execute.tsx
+++ b/frontend/src/pages/raw-execute/raw-execute.tsx
@@ -10,14 +10,16 @@ import { Table } from "../../components/table";
 import { InternalRoutes } from "../../config/routes";
 import { DatabaseType, useRawExecuteLazyQuery } from "../../generated/graphql";
 import { useAppSelector } from "../../store/hooks";
+import classNames from "classnames";
 
 type IRawExecuteCellProps = {
     cellId: string;
     onAdd: (cellId: string) => void;
     onDelete?: (cellId: string) => void;
+    showTools?: boolean;
 }
 
-const RawExecuteCell: FC<IRawExecuteCellProps> = ({ cellId, onAdd, onDelete }) => {
+const RawExecuteCell: FC<IRawExecuteCellProps> = ({ cellId, onAdd, onDelete, showTools }) => {
     const [code, setCode] = useState("");
     const [rawExecute, { data: rows, loading, error }] = useRawExecuteLazyQuery();
 
@@ -50,7 +52,9 @@ const RawExecuteCell: FC<IRawExecuteCellProps> = ({ cellId, onAdd, onDelete }) =
                         : <CodeEditor language="sql" value={code} setValue={setCode} onRun={handleRawExecute} />
                     }
                 </div>
-                <div className="absolute -bottom-3 z-20 flex justify-between px-3 pr-8 w-full opacity-0 transition-all duration-500 group-hover/cell:opacity-100">
+                <div className={classNames("absolute -bottom-3 z-20 flex justify-between px-3 pr-8 w-full opacity-0 transition-all duration-500 group-hover/cell:opacity-100", {
+                    "opacity-100": showTools,
+                })}>
                     <div className="flex gap-2">
                         <AnimatedButton icon={Icons.PlusCircle} label="Add" onClick={handleAdd} />
                         {
@@ -102,7 +106,8 @@ export const RawExecutePage: FC = () => {
                         cellIds.map((cellId, index) => (
                             <>
                                 {index > 0 && <div className="border-dashed border-t border-gray-300 my-2 dark:border-neutral-600"></div>}
-                                <RawExecuteCell key={cellId} cellId={cellId} onAdd={handleAdd} onDelete={cellIds.length <= 1 ? undefined : handleDelete} />
+                                <RawExecuteCell key={cellId} cellId={cellId} onAdd={handleAdd} onDelete={cellIds.length <= 1 ? undefined : handleDelete}
+                                    showTools={cellIds.length === 1} />
                             </>
                         ))
                     }

--- a/frontend/src/pages/storage-unit/explore-storage-unit-where-condition.tsx
+++ b/frontend/src/pages/storage-unit/explore-storage-unit-where-condition.tsx
@@ -1,0 +1,118 @@
+import classNames from "classnames";
+import { AnimatePresence, motion } from "framer-motion";
+import { FC, useCallback, useEffect, useMemo, useState } from "react";
+import { ActionButton, AnimatedButton } from "../../components/button";
+import { createDropdownItem, Dropdown, IDropdownItem } from "../../components/dropdown";
+import { Icons } from "../../components/icons";
+import { Input, Label } from "../../components/input";
+
+export type IExploreStorageUnitWhereConditionFilter = {
+    field: string;
+    operator: string;
+    value: string;
+}
+
+type IExploreStorageUnitWhereConditionProps = {
+    options: string[];
+    operators: string[];
+    onChange?: (filters: IExploreStorageUnitWhereConditionFilter[]) => void;
+}
+
+export const ExploreStorageUnitWhereCondition: FC<IExploreStorageUnitWhereConditionProps> = ({ options, onChange, operators }) => {
+    const [newFilter, setNewFilter] = useState<IExploreStorageUnitWhereConditionFilter>({ field: options[0], operator: operators[0], value: "" });
+    const [filters, setFitlers] = useState<IExploreStorageUnitWhereConditionFilter[]>([]);
+    const [show, setShow] = useState(false);
+
+    const handleClick = useCallback(() => {
+        setShow(s => !s);
+    }, []);
+
+    const fieldsDropdownItems = useMemo(() => {
+        return options.map(option => createDropdownItem(option));
+    }, [options]);
+
+    const handleFieldSelect = useCallback((item: IDropdownItem) => {
+        setNewFilter(val => ({
+            ...val,
+            field: item.id,
+        }));
+    }, []);
+
+    const handleOperatorSelector = useCallback((item: IDropdownItem) => {
+        setNewFilter(val => ({
+            ...val,
+            operator: item.id,
+        }));
+    }, []);
+
+    const handleInputChange = useCallback((newValue: string) => {
+        setNewFilter(val => ({
+            ...val,
+            value: newValue,
+        }));
+    }, []);
+
+    const handleAddFilter = useCallback(() => {
+        const newFilters = [...filters, newFilter];
+        setFitlers(newFilters);
+        setNewFilter({ field: newFilter.field, operator: operators[0], value: "" });
+        onChange?.(newFilters);
+    }, [filters, newFilter, onChange, operators]);
+
+    const handleRemove = useCallback((index: number) => {
+        setFitlers(oldFilters => oldFilters.filter((_, i) => i !== index));
+    }, []);
+
+    useEffect(() => {
+        setNewFilter(f => ({
+            ...f,
+            operator: operators[0],
+        }));
+    }, [operators]);
+
+    const validOperators = useMemo(() => {
+        return operators.map(operator => createDropdownItem(operator));
+    }, [operators]);
+    
+    return <div className="flex flex-col gap-1 h-full relative">
+        <Label label="Where condition" />
+        <div className="flex gap-1 items-center max-w-[min(500px,calc(100vw-20px))] flex-wrap">
+            {
+                filters.map((filter, i) => (
+                    <div className="group/filter-item flex gap-1 items-center text-xs px-2 py-1 rounded-2xl dark:bg-white/5 cursor-pointer relative overflow-hidden shadow-sm border border-neutral-100 dark:border-neutral-800"
+                        onClick={() => handleRemove(i)}>
+                        <div className="max-w-[350px] truncate  dark:text-neutral-300">
+                            {filter.field} {filter.operator} {filter.value}
+                        </div>
+                        <ActionButton icon={Icons.Cancel} containerClassName="hover:scale-125 absolute right-0 top-1/2 -translate-y-1/2 z-10 h-4 w-4 opacity-0 group-hover/filter-item:opacity-100" />
+                    </div>
+                ))
+            }
+            <ActionButton className={classNames("transition-all", {
+                "rotate-45": show,
+            })} icon={Icons.Add} containerClassName="h-8 w-8" onClick={handleClick} />
+        </div>
+        <AnimatePresence mode="wait">
+            {
+                show &&
+                <motion.div className="flex gap-1 z-[5] py-2 px-4 absolute top-full mt-1 rounded-lg shadow-md border border-neutral-100  dark:border-white/5 dark:bg-white/20 dark:backdrop-blur-xl translate-y-full bg-white" initial={{
+                    y: -10,
+                    opacity: 0,
+                }} animate={{
+                    y: 0,
+                    opacity: 1,
+                }} exit={{
+                    y: -10,
+                    opacity: 0,
+                }}>
+                    <Dropdown className="min-w-[100px]" value={createDropdownItem(newFilter.field)} items={fieldsDropdownItems} onChange={handleFieldSelect} />
+                    <Dropdown className="min-w-20" value={createDropdownItem(newFilter.operator)} items={validOperators} onChange={handleOperatorSelector} />
+                    <Input inputProps={{
+                        className: "min-w-[150px]"
+                    }} placeholder="Enter filter value" value={newFilter.value} setValue={handleInputChange} />
+                    <AnimatedButton className="dark:bg-white/5" icon={Icons.CheckCircle} label="Add" onClick={handleAddFilter} />
+                </motion.div>
+            }
+        </AnimatePresence>
+    </div>
+}

--- a/frontend/src/pages/storage-unit/explore-storage-unit-where-condition.tsx
+++ b/frontend/src/pages/storage-unit/explore-storage-unit-where-condition.tsx
@@ -5,6 +5,7 @@ import { ActionButton, AnimatedButton } from "../../components/button";
 import { createDropdownItem, Dropdown, IDropdownItem } from "../../components/dropdown";
 import { Icons } from "../../components/icons";
 import { Input, Label } from "../../components/input";
+import { twMerge } from "tailwind-merge";
 
 export type IExploreStorageUnitWhereConditionFilter = {
     field: string;
@@ -13,58 +14,88 @@ export type IExploreStorageUnitWhereConditionFilter = {
 }
 
 type IExploreStorageUnitWhereConditionProps = {
+    defaultFilters?: IExploreStorageUnitWhereConditionFilter[];
     options: string[];
     operators: string[];
     onChange?: (filters: IExploreStorageUnitWhereConditionFilter[]) => void;
 }
 
-export const ExploreStorageUnitWhereCondition: FC<IExploreStorageUnitWhereConditionProps> = ({ options, onChange, operators }) => {
-    const [newFilter, setNewFilter] = useState<IExploreStorageUnitWhereConditionFilter>({ field: options[0], operator: operators[0], value: "" });
+export const ExploreStorageUnitWhereCondition: FC<IExploreStorageUnitWhereConditionProps> = ({ defaultFilters, options, onChange, operators }) => {
+    const [currentFilter, setCurrentFilter] = useState<IExploreStorageUnitWhereConditionFilter>({ field: options[0], operator: operators[0], value: "" });
     const [filters, setFitlers] = useState<IExploreStorageUnitWhereConditionFilter[]>([]);
-    const [show, setShow] = useState(false);
+    const [newFilter, setNewFilter] = useState(false);
+    const [editingFilter, setEditingFilter] = useState(-1);
 
     const handleClick = useCallback(() => {
-        setShow(s => !s);
-    }, []);
+        const shouldShow = !newFilter;
+        if (shouldShow) {
+            setEditingFilter(-1);
+            setCurrentFilter({ field: currentFilter.field, operator: operators[0], value: "" });
+        }
+        setNewFilter(!newFilter);
+    }, [currentFilter.field, operators, newFilter]);
 
     const fieldsDropdownItems = useMemo(() => {
         return options.map(option => createDropdownItem(option));
     }, [options]);
 
     const handleFieldSelect = useCallback((item: IDropdownItem) => {
-        setNewFilter(val => ({
+        setCurrentFilter(val => ({
             ...val,
             field: item.id,
         }));
     }, []);
 
     const handleOperatorSelector = useCallback((item: IDropdownItem) => {
-        setNewFilter(val => ({
+        setCurrentFilter(val => ({
             ...val,
             operator: item.id,
         }));
     }, []);
 
     const handleInputChange = useCallback((newValue: string) => {
-        setNewFilter(val => ({
+        setCurrentFilter(val => ({
             ...val,
             value: newValue,
         }));
     }, []);
 
     const handleAddFilter = useCallback(() => {
-        const newFilters = [...filters, newFilter];
+        const newFilters = [...filters, currentFilter];
         setFitlers(newFilters);
-        setNewFilter({ field: newFilter.field, operator: operators[0], value: "" });
+        setCurrentFilter({ field: currentFilter.field, operator: operators[0], value: "" });
         onChange?.(newFilters);
-    }, [filters, newFilter, onChange, operators]);
+    }, [filters, currentFilter, onChange, operators]);
 
     const handleRemove = useCallback((index: number) => {
-        setFitlers(oldFilters => oldFilters.filter((_, i) => i !== index));
-    }, []);
+        setEditingFilter(-1);
+        const newFilters = filters.filter((_, i) => i !== index)
+        setFitlers(newFilters);
+        onChange?.(newFilters);
+    }, [filters, onChange]);
+
+    const handleEdit = useCallback((index: number) => {
+        if (editingFilter === index) {
+            setEditingFilter(-1);
+            setCurrentFilter({ field: currentFilter.field, operator: operators[0], value: "" });
+            return;
+        }
+        setNewFilter(false);
+        setCurrentFilter(filters[index]);
+        setEditingFilter(index);
+    }, [editingFilter, filters, currentFilter.field, operators]);
+
+    const handleSaveFilter = useCallback((index: number) => {
+        const newFilters = [...filters];
+        newFilters[index] = {...currentFilter};
+        setFitlers(newFilters);
+        setEditingFilter(-1);
+        setCurrentFilter({ field: currentFilter.field, operator: operators[0], value: "" });
+        onChange?.(newFilters);
+    }, [currentFilter, filters, onChange, operators]);
 
     useEffect(() => {
-        setNewFilter(f => ({
+        setCurrentFilter(f => ({
             ...f,
             operator: operators[0],
         }));
@@ -73,28 +104,57 @@ export const ExploreStorageUnitWhereCondition: FC<IExploreStorageUnitWhereCondit
     const validOperators = useMemo(() => {
         return operators.map(operator => createDropdownItem(operator));
     }, [operators]);
-    
+
+    useEffect(() => {
+        setFitlers(defaultFilters ?? []);
+    }, [defaultFilters]);
+
     return <div className="flex flex-col gap-1 h-full relative">
         <Label label="Where condition" />
         <div className="flex gap-1 items-center max-w-[min(500px,calc(100vw-20px))] flex-wrap">
             {
                 filters.map((filter, i) => (
-                    <div className="group/filter-item flex gap-1 items-center text-xs px-2 py-1 rounded-2xl dark:bg-white/5 cursor-pointer relative overflow-hidden shadow-sm border border-neutral-100 dark:border-neutral-800"
-                        onClick={() => handleRemove(i)}>
-                        <div className="max-w-[350px] truncate  dark:text-neutral-300">
+                    <div key={`explore-storage-unit-filter-${i}`} className="group/filter-item flex gap-1 items-center text-xs rounded-2xl dark:bg-white/5 cursor-pointer relative shadow-sm border border-neutral-100 dark:border-neutral-800">
+                        <div className={twMerge(classNames("px-2 py-1 h-full max-w-[350px] truncate dark:text-neutral-300 rounded-2xl", {
+                            "dark:bg-white/10": editingFilter === i,
+                        }))} onClick={() => handleEdit(i)}>
                             {filter.field} {filter.operator} {filter.value}
                         </div>
-                        <ActionButton icon={Icons.Cancel} containerClassName="hover:scale-125 absolute right-0 top-1/2 -translate-y-1/2 z-10 h-4 w-4 opacity-0 group-hover/filter-item:opacity-100" />
+                        <ActionButton icon={Icons.Cancel} containerClassName="hover:scale-125 absolute right-2 top-1/2 -translate-y-1/2 z-10 h-4 w-4 opacity-0 group-hover/filter-item:opacity-100"
+                            onClick={() => handleRemove(i)} />
+                        <AnimatePresence mode="wait">
+                            {
+                                editingFilter === i &&
+                                <motion.div className="flex gap-1 z-[5] py-2 px-4 absolute left-0 top-full mt-2 rounded-lg shadow-md border border-neutral-100  dark:border-white/5 dark:bg-white/20 dark:backdrop-blur-xl translate-y-full bg-white" initial={{
+                                    y: -10,
+                                    opacity: 0,
+                                }} animate={{
+                                    y: 0,
+                                    opacity: 1,
+                                }} exit={{
+                                    y: -10,
+                                    opacity: 0,
+                                }}>
+                                    <Dropdown noItemsLabel="No fields found" className="min-w-[100px]" value={createDropdownItem(currentFilter.field)} items={fieldsDropdownItems.length === 0 ? [createDropdownItem(currentFilter.field)] : fieldsDropdownItems} onChange={handleFieldSelect} />
+                                    <Dropdown noItemsLabel="No operators found" className="min-w-20" value={createDropdownItem(currentFilter.operator)} items={validOperators} onChange={handleOperatorSelector} />
+                                    <Input inputProps={{
+                                        className: "min-w-[150px]"
+                                    }} placeholder="Enter filter value" value={currentFilter.value} setValue={handleInputChange} />
+                                    <AnimatedButton className="dark:bg-white/5" icon={Icons.Cancel} label="Cancel" onClick={() => handleEdit(i)} />
+                                    <AnimatedButton className="dark:bg-white/5" icon={Icons.CheckCircle} label="Save" onClick={() => handleSaveFilter(i)} />
+                                </motion.div>
+                            }
+                        </AnimatePresence>
                     </div>
                 ))
             }
             <ActionButton className={classNames("transition-all", {
-                "rotate-45": show,
+                "rotate-45": newFilter,
             })} icon={Icons.Add} containerClassName="h-8 w-8" onClick={handleClick} />
         </div>
         <AnimatePresence mode="wait">
             {
-                show &&
+                newFilter &&
                 <motion.div className="flex gap-1 z-[5] py-2 px-4 absolute top-full mt-1 rounded-lg shadow-md border border-neutral-100  dark:border-white/5 dark:bg-white/20 dark:backdrop-blur-xl translate-y-full bg-white" initial={{
                     y: -10,
                     opacity: 0,
@@ -105,11 +165,12 @@ export const ExploreStorageUnitWhereCondition: FC<IExploreStorageUnitWhereCondit
                     y: -10,
                     opacity: 0,
                 }}>
-                    <Dropdown className="min-w-[100px]" value={createDropdownItem(newFilter.field)} items={fieldsDropdownItems} onChange={handleFieldSelect} />
-                    <Dropdown className="min-w-20" value={createDropdownItem(newFilter.operator)} items={validOperators} onChange={handleOperatorSelector} />
+                    <Dropdown noItemsLabel="No fields found" className="min-w-[100px]" value={createDropdownItem(currentFilter.field)} items={fieldsDropdownItems} onChange={handleFieldSelect} />
+                    <Dropdown noItemsLabel="No operators found" className="min-w-20" value={createDropdownItem(currentFilter.operator)} items={validOperators} onChange={handleOperatorSelector} />
                     <Input inputProps={{
-                        className: "min-w-[150px]"
-                    }} placeholder="Enter filter value" value={newFilter.value} setValue={handleInputChange} />
+                        className: "min-w-[150px]",
+                    }} placeholder="Enter filter value" value={currentFilter.value} setValue={handleInputChange} />
+                    <AnimatedButton className="dark:bg-white/5" icon={Icons.Cancel} label="Cancel" onClick={handleClick} />
                     <AnimatedButton className="dark:bg-white/5" icon={Icons.CheckCircle} label="Add" onClick={handleAddFilter} />
                 </motion.div>
             }

--- a/frontend/src/pages/storage-unit/explore-storage-unit.tsx
+++ b/frontend/src/pages/storage-unit/explore-storage-unit.tsx
@@ -194,7 +194,11 @@ export const ExploreStorageUnit: FC = () => {
             case DatabaseType.MySql:
             case DatabaseType.Sqlite3:
             case DatabaseType.MariaDb:
-                return ["=", ">=", ">", "<=", "<"];
+                return [
+                    "=", ">=", ">", "<=", "<", "<>", "!=", "!>", "!<", "BETWEEN", "NOT BETWEEN", 
+                    "LIKE", "NOT LIKE", "IN", "NOT IN", "IS NULL", "IS NOT NULL", "AND", "OR", 
+                    "NOT"
+                ];
             case DatabaseType.ElasticSearch:
                 return [
                     "match", "match_phrase", "match_phrase_prefix", "multi_match", "bool", 

--- a/frontend/src/pages/storage-unit/storage-unit.tsx
+++ b/frontend/src/pages/storage-unit/storage-unit.tsx
@@ -107,7 +107,7 @@ export const StorageUnitPage: FC = () => {
 
     return <InternalPage routes={routes}>
         <div className="flex w-full h-fit my-2 gap-2">
-            <AnimatedButton icon={Icons.Console} label="Raw Query" onClick={() => navigate(InternalRoutes.RawExecute.path)} type="lg" />
+            <AnimatedButton icon={Icons.Console} label="Scratchpad" onClick={() => navigate(InternalRoutes.RawExecute.path)} type="lg" />
         </div>
         {
             data != null && (


### PR DESCRIPTION
This PR abstracts all the filters with the same UI across all DBs:

<img width="888" alt="image" src="https://github.com/user-attachments/assets/4c120949-6b1e-4974-b199-350afda1f7cd">


The operators change based on the database used [elastic search]:
<img width="270" alt="image" src="https://github.com/user-attachments/assets/5f5d3613-6d23-4e6c-a9dd-56a080c5f8af">

Postgres:
<img width="861" alt="image" src="https://github.com/user-attachments/assets/5640d23f-2f1e-4d96-b5ae-b59fee866dc4">

Conditions will be shown as pills:
<img width="376" alt="image" src="https://github.com/user-attachments/assets/8df76098-4059-4282-8a09-ab342ef2057b">

Clicking on a Pill will allow you to edit the filter easily:
<img width="619" alt="image" src="https://github.com/user-attachments/assets/43debf19-cae7-430e-b27e-d8da37786146">

Further you can hit a cross to delete the filter:
<img width="77" alt="image" src="https://github.com/user-attachments/assets/d9c9a02f-30ee-44d0-bf3a-4bd91f9c1be5">

**Limitations:**
The fields are taken from the data received. This means if there is no data received - there will be no fields shown in the dropdown.