### PR TITLE
Fix blurry export from graph

### DIFF
--- a/frontend/src/components/graph/graph.tsx
+++ b/frontend/src/components/graph/graph.tsx
@@ -88,7 +88,9 @@ export const Graph: FC<IGraphProps> = (props) => {
           }
       
           setDownloading(true);
-          toPng(reactFlowWrapper.current)
+          toPng(reactFlowWrapper.current, {
+            pixelRatio: 5,
+          })
             .then((dataUrl) => {
               const link = document.createElement('a');
               link.download = 'clidey-whodb-diagram.png';


### PR DESCRIPTION
- [frontend]: add high quality image download from the graph itself.

Demo (Zoomed in photo ~50%):
<img width="1542" alt="image" src="https://github.com/user-attachments/assets/c2e3356e-c4ad-4979-9991-75e5cc000076">
