### PR TITLE
[Feature] Add multi select to table to allow easy delete and export

### DIFF
--- a/frontend/src/components/hooks.tsx
+++ b/frontend/src/components/hooks.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 
-export const useExportToCSV = (columns: string[], rows: Record<string, string>[], specificIndexes: number[] = []) => {
+export const useExportToCSV = (columns: string[], rows: Record<string, string | number>[], specificIndexes: number[] = []) => {
     return useCallback(() => {
-      let selectedRows: Record<string, string>[];
+      let selectedRows: Record<string, string | number>[];
       if (specificIndexes.length === 0) {
         selectedRows = rows;
       } else {

--- a/frontend/src/components/hooks.tsx
+++ b/frontend/src/components/hooks.tsx
@@ -1,11 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 
-export const useExportToCSV = (columns: string[], rows: Record<string, string>[]) => {
+export const useExportToCSV = (columns: string[], rows: Record<string, string>[], specificIndexes: number[] = []) => {
     return useCallback(() => {
+      let selectedRows: Record<string, string>[];
+      if (specificIndexes.length === 0) {
+        selectedRows = rows;
+      } else {
+        selectedRows = specificIndexes.map(index => rows[index]);
+      }
       const csvContent = [
         columns.join(','), 
-        ...rows.map(row => columns.map(col => row[col]).join(","))
+        ...selectedRows.map(row => columns.map(col => row[col]).join(","))
       ].join('\n'); 
   
       const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
@@ -20,7 +26,7 @@ export const useExportToCSV = (columns: string[], rows: Record<string, string>[]
         link.click();
         document.body.removeChild(link);
       }
-    }, [columns, rows]);
+    }, [columns, rows, specificIndexes]);
 };
 
 type ILongPressProps = {

--- a/frontend/src/components/input.tsx
+++ b/frontend/src/components/input.tsx
@@ -77,3 +77,19 @@ export const ToggleInput: FC<IToggleInputProps> = ({ value, setValue }) => {
         </label>
     );
 }
+
+
+type ICheckBoxInputProps = {
+    value: boolean;
+    setValue?: (value: boolean) => void;
+}
+
+export const CheckBoxInput: FC<ICheckBoxInputProps> = ({ value, setValue }) => {
+    const handleChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+        setValue?.(e.target.checked);
+    }, [setValue]);
+
+    return (
+        <input className="hover:cursor-pointer" type="checkbox" checked={value} onChange={handleChange} />
+    );
+}

--- a/frontend/src/components/input.tsx
+++ b/frontend/src/components/input.tsx
@@ -90,6 +90,6 @@ export const CheckBoxInput: FC<ICheckBoxInputProps> = ({ value, setValue }) => {
     }, [setValue]);
 
     return (
-        <input className="hover:cursor-pointer" type="checkbox" checked={value} onChange={handleChange} />
+        <input className="hover:cursor-pointer accent-[#ca6f1e] dark:accent-[#ca6f1e]" type="checkbox" checked={value} onChange={handleChange} />
     );
 }

--- a/frontend/src/components/table.tsx
+++ b/frontend/src/components/table.tsx
@@ -588,7 +588,7 @@ export const Table: FC<ITableProps> = ({ className, columns: actualColumns, rows
                 </div>
                 <div className="flex gap-4 items-center">
                     <div className="text-sm text-gray-600 dark:text-neutral-300"><span className="font-semibold">Count:</span> {rowCount}</div>
-                    <AnimatedButton icon={Icons.Download} label="Export" type="lg" onClick={exportToCSV} />
+                    <AnimatedButton icon={Icons.Download} label={checkedRows != null && checkedRows?.size > 0 ? "Export selected" : "Export"} type="lg" onClick={exportToCSV} />
                 </div>
             </div>
             <div className={twMerge(classNames("flex overflow-x-auto h-full", className))} style={{

--- a/frontend/src/pages/storage-unit/explore-storage-unit.tsx
+++ b/frontend/src/pages/storage-unit/explore-storage-unit.tsx
@@ -81,7 +81,7 @@ export const ExploreStorageUnit: FC = () => {
         setCurrentPage(0);
     }, [handleSubmitRequest]);
 
-    const handleRowUpdate = useCallback((row: Record<string, string>) => {
+    const handleRowUpdate = useCallback((row: Record<string, string | number>) => {
         if (current == null) {
             return Promise.reject();
         }


### PR DESCRIPTION
Add multiple select logic.

Note: when sorting, it tracks the original index as it uses index as the identifier. This is majorly because there is no easy way to find identifier for a table row (primary key might or might not be present).

Demo:

On hover:
<img width="712" alt="image" src="https://github.com/user-attachments/assets/feeba636-7583-4ae4-aefa-dfd43fb26892">

On header [allows selecting all]:
<img width="108" alt="image" src="https://github.com/user-attachments/assets/e8c96f87-489a-435f-9051-de9f51327c83">

<img width="317" alt="image" src="https://github.com/user-attachments/assets/4590cfab-4def-404b-b366-f14617054768">

The delete and export changes based on the number of rows selected

<img width="393" alt="image" src="https://github.com/user-attachments/assets/62e18d18-b96d-4d13-b1e3-0ec2f85a39dd">

If one selected:
<img width="197" alt="image" src="https://github.com/user-attachments/assets/1cdcf7ee-0c2b-498c-867f-dc695ce44ad9">


If none selected:

<img width="229" alt="image" src="https://github.com/user-attachments/assets/8db8770f-b6ad-4727-b4f0-d9b7231e2133">
