### PR TITLE
[Release] Support for Ollama inside Docker

### DIFF
--- a/core/src/common/utils.go
+++ b/core/src/common/utils.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
@@ -74,4 +75,9 @@ func JoinWithQuotes(arr []string) string {
 	}
 
 	return strings.Join(quotedStrings, ", ")
+}
+
+func IsRunningInsideDocker() bool {
+	_, err := os.Stat("/.dockerenv")
+	return !os.IsNotExist(err)
 }

--- a/core/src/env/env.go
+++ b/core/src/env/env.go
@@ -10,6 +10,8 @@ import (
 )
 
 var IsDevelopment = os.Getenv("ENVIRONMENT") == "dev"
+var OllamaHost = os.Getenv("WHODB_OLLAMA_HOST")
+var OllamaPort = os.Getenv("WHODB_OLLAMA_PORT")
 
 type DatabaseCredentials struct {
 	Hostname string            `json:"host"`

--- a/core/src/router/router.go
+++ b/core/src/router/router.go
@@ -11,6 +11,7 @@ import (
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/clidey/whodb/core/graph"
 	"github.com/clidey/whodb/core/src/auth"
+	"github.com/clidey/whodb/core/src/common"
 	"github.com/clidey/whodb/core/src/log"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -69,7 +70,7 @@ func InitializeRouter(staticFiles embed.FS) {
 	log.Logger.Infof("http://0.0.0.0:%s", port)
 	log.Logger.Info("Explore and enjoy working with your databases!")
 
-	if !isDocker() {
+	if !common.IsRunningInsideDocker() {
 		openBrowser(fmt.Sprintf("http://localhost:%v", port))
 	}
 

--- a/core/src/router/task.go
+++ b/core/src/router/task.go
@@ -1,7 +1,6 @@
 package router
 
 import (
-	"os"
 	"os/exec"
 	"runtime"
 
@@ -23,9 +22,4 @@ func openBrowser(url string) {
 	if err != nil {
 		log.Logger.Warnf("Failed to open browser: %v\n", err)
 	}
-}
-
-func isDocker() bool {
-	_, err := os.Stat("/.dockerenv")
-	return !os.IsNotExist(err)
 }


### PR DESCRIPTION
This PR will automatically find the "host.internal.docker" host if WhoDB is running inside of Docker.

This can be overwritten by two environment variables:

- WHODB_OLLAMA_HOST: This will overwrite the host of the Ollama instance
- WHODB_OLLAMA_PORT: This will overwrite the port of the Ollama instance

Houdini will be available automatically on the left side once the Ollama instance is found: 
<img width="327" alt="image" src="https://github.com/user-attachments/assets/69ca6979-d675-4fe2-95e5-5f2d8bb1907a">
