### PR TITLE
Redesign login page and fix raw execute response bug

### DIFF
--- a/frontend/src/pages/auth/login.tsx
+++ b/frontend/src/pages/auth/login.tsx
@@ -264,7 +264,7 @@ export const LoginPage: FC = () => {
 
     return (
         <Container className="justify-center items-center">
-            <div className={twMerge(BASE_CARD_CLASS, "w-fit h-fit")}>
+            <div className="w-fit h-fit">
                 <div className="flex flex-col justify-between grow gap-4">
                     <div className="flex grow">
                         <div className="flex flex-col gap-4 grow w-[350px]">

--- a/frontend/src/pages/raw-execute/raw-execute.tsx
+++ b/frontend/src/pages/raw-execute/raw-execute.tsx
@@ -20,9 +20,11 @@ type IRawExecuteCellProps = {
 
 const RawExecuteCell: FC<IRawExecuteCellProps> = ({ cellId, onAdd, onDelete, showTools }) => {
     const [code, setCode] = useState("");
+    const [submittedCode, setSubmittedCode] = useState("");
     const [rawExecute, { data: rows, loading, error }] = useRawExecuteLazyQuery();
 
     const handleRawExecute = useCallback(() => {
+        setSubmittedCode(code);
         rawExecute({
             variables: {
                 query: code,
@@ -40,9 +42,9 @@ const RawExecuteCell: FC<IRawExecuteCellProps> = ({ cellId, onAdd, onDelete, sho
     }, [cellId, onDelete]);
 
 
-    const codeWithoutComments = useMemo(() => {
-        return code.split("\n").filter(text => !text.startsWith("--")).join("\n");
-    }, [code]);
+    const isCodeAQuery = useMemo(() => {
+        return submittedCode.split("\n").filter(text => !text.startsWith("--")).join("\n").trim().toLowerCase().startsWith("select");
+    }, [submittedCode]);
 
     return <div className="flex flex-col grow group/cell">
             <div className="relative">
@@ -73,8 +75,8 @@ const RawExecuteCell: FC<IRawExecuteCellProps> = ({ cellId, onAdd, onDelete, sho
                 </div>
             }
             {
-                rows != null && 
-                (codeWithoutComments.trim().startsWith("SELECT")
+                rows != null && submittedCode.length > 0 && 
+                (isCodeAQuery
                     ?
                         <div className="flex flex-col w-full h-[250px] mt-4">
                             <Table columns={rows.RawExecute.Columns.map(c => c.Name)} columnTags={rows.RawExecute.Columns.map(c => c.Type)}


### PR DESCRIPTION
- Remove card layout on the login page for a cleaner look
- Fix raw execute response viewer to keep cache of submitted code and show table on select queries (case insensitive check)

Login page: 
<img width="860" alt="image" src="https://github.com/user-attachments/assets/fa390e1f-915b-405a-aa2a-faa90653fc84">

