### PR TITLE
Sort tables in storage-unit alphabetically

### DIFF
--- a/frontend/src/pages/storage-unit/storage-unit.tsx
+++ b/frontend/src/pages/storage-unit/storage-unit.tsx
@@ -217,7 +217,8 @@ export const StorageUnitPage: FC = () => {
 
     const filterStorageUnits = useMemo(() => {
         const lowerCaseFilterValue = filterValue.toLowerCase();
-        return filter(data?.StorageUnit ?? [], unit => unit.Name.toLowerCase().includes(lowerCaseFilterValue));
+        return filter(data?.StorageUnit ?? [], unit => unit.Name.toLowerCase().includes(lowerCaseFilterValue))
+            .sort((a, b) => a.Name.localeCompare(b.Name));
     }, [data?.StorageUnit, filterValue]);
 
     if (loading) {


### PR DESCRIPTION
Right now, the Card tables shown in storage-unit are ordered arbitrarily in the order that they arrive in.
Sorting them provides a better user experience.

Before:
![image](https://github.com/user-attachments/assets/440c7c4d-293b-43a3-b06b-2e76894fc82c)

After:
![image](https://github.com/user-attachments/assets/0db0858b-47eb-4e33-ad5e-61450ad897ef)
