### PR TITLE
Ensure ids are unique for columns with same name

### DIFF
--- a/frontend/src/components/table.tsx
+++ b/frontend/src/components/table.tsx
@@ -385,12 +385,23 @@ export const Table: FC<ITableProps> = ({ className, columns: actualColumns, rows
     const columns = useMemo(() => {
         const indexWidth = 50;
         const colWidth = Math.max(((width - indexWidth)/actualColumns.length), 150);
-        const cols = actualColumns.map(col => ({
-            id: col,
-            Header: col,
-            accessor: col,
-            width: colWidth,
-        }));
+        const headerCount: Record<string, number> = {};
+        const cols = actualColumns.map((col) => {
+            if (headerCount[col] === undefined) {
+                headerCount[col] = 0;
+            } else {
+                headerCount[col] += 1;
+            }
+
+            const id = headerCount[col] > 0 ? `${col}-${headerCount[col]}` : col;
+
+            return {
+                id,
+                Header: col,
+                accessor: id,
+                width: colWidth,
+            };
+        });
         cols.unshift({
             id: "#",
             Header: "#",
@@ -403,7 +414,11 @@ export const Table: FC<ITableProps> = ({ className, columns: actualColumns, rows
     useEffect(() => {
         setData(actualRows.map((row, rowIndex) => {
             const newRow = row.reduce((all, one, colIndex) => {
-                all[actualColumns[colIndex]] = one;
+                if (actualColumns[colIndex] === "#") {
+                    all[actualColumns[colIndex]] = one;
+                } else {
+                    all[columns[colIndex+1].accessor] = one;
+                }
                 return all;
             }, { "#": (rowIndex+1).toString() } as Record<string, string | number>);
             newRow.originalIndex = rowIndex;

--- a/frontend/src/components/table.tsx
+++ b/frontend/src/components/table.tsx
@@ -387,7 +387,7 @@ export const Table: FC<ITableProps> = ({ className, columns: actualColumns, rows
         const colWidth = Math.max(((width - indexWidth)/actualColumns.length), 150);
         const headerCount: Record<string, number> = {};
         const cols = actualColumns.map((col) => {
-            if (headerCount[col] === undefined) {
+            if (headerCount[col] == null) {
                 headerCount[col] = 0;
             } else {
                 headerCount[col] += 1;


### PR DESCRIPTION
Fixes Issue: https://github.com/clidey/whodb/issues/316

This PR allows tables to have unique identifier and accessor such that similar headers are going to have an incremented key. This still shows the column names as the same but the values would be different and the order in which the columns are shown is the same the query.

Demo:
<img width="957" alt="image" src="https://github.com/user-attachments/assets/0085698a-5d66-4e40-9a24-456d789e743e" />
