### PR TITLE
fix: MySQL CAST AS BIGINT to proper type conversion

### DIFF
--- a/core/src/plugins/mysql/utils.go
+++ b/core/src/plugins/mysql/utils.go
@@ -20,7 +20,10 @@ import (
 )
 
 func (p *MySQLPlugin) ConvertStringValueDuringMap(value, columnType string) (interface{}, error) {
-	return value, nil
+	// Let the base GORM plugin handle the conversion
+	// This will convert string values to proper Go types (int64, float64, etc.)
+	// which prevents GORM from generating CAST statements
+	return p.ConvertStringValue(value, columnType)
 }
 
 func (p *MySQLPlugin) EscapeSpecificIdentifier(identifier string) string {


### PR DESCRIPTION
MySQL doesn't support CAST AS BIGINT syntax. Fixed by implementing
ConvertStringValueDuringMap to properly convert string values to Go
types, preventing GORM from generating invalid CAST statements.

Fixes #613

Generated with [Claude Code](https://claude.ai/code)