### PR TITLE
feat: Add optional schema field to CLI connection form

### DIFF
--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -208,7 +208,7 @@ func init() {
 	connectCmd.Flags().IntVar(&port, "port", 0, "database port (default depends on database type)")
 	connectCmd.Flags().StringVar(&username, "user", "", "database username")
 	connectCmd.Flags().StringVar(&database, "database", "", "database name")
-	connectCmd.Flags().StringVar(&schema, "schema", "", "default schema (optional)")
+	connectCmd.Flags().StringVar(&schema, "schema", "", "preferred schema (PostgreSQL: schema name; MySQL: not needed; MongoDB: not applicable)")
 	connectCmd.Flags().StringVar(&name, "name", "", "connection name (save for later use)")
 	connectCmd.Flags().BoolVar(&passwordFromStdin, "password", false, "read password from stdin when not using a TTY")
 }

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -37,6 +37,7 @@ var (
 	port              int
 	username          string
 	database          string
+	schema            string
 	name              string
 	passwordFromStdin bool
 )
@@ -119,6 +120,7 @@ Usage modes:
 				Username: username,
 				Password: password,
 				Database: database,
+				Schema:   schema,
 			}
 
 			if name != "" {
@@ -206,6 +208,7 @@ func init() {
 	connectCmd.Flags().IntVar(&port, "port", 0, "database port (default depends on database type)")
 	connectCmd.Flags().StringVar(&username, "user", "", "database username")
 	connectCmd.Flags().StringVar(&database, "database", "", "database name")
+	connectCmd.Flags().StringVar(&schema, "schema", "", "default schema (optional)")
 	connectCmd.Flags().StringVar(&name, "name", "", "connection name (save for later use)")
 	connectCmd.Flags().BoolVar(&passwordFromStdin, "password", false, "read password from stdin when not using a TTY")
 }

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -41,6 +41,7 @@ type Connection struct {
 	Username string            `json:"username" yaml:"username"`
 	Password string            `json:"password,omitempty" yaml:"password,omitempty"`
 	Database string            `json:"database" yaml:"database"`
+	Schema   string            `json:"schema,omitempty" yaml:"schema,omitempty"`
 	Advanced map[string]string `json:"advanced,omitempty" yaml:"advanced,omitempty"`
 }
 

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -41,6 +41,11 @@ type Connection struct {
 	Username string            `json:"username" yaml:"username"`
 	Password string            `json:"password,omitempty" yaml:"password,omitempty"`
 	Database string            `json:"database" yaml:"database"`
+	// Schema field is optional and database-specific:
+	// - PostgreSQL: Specific schema within the database (e.g., "public", "staging")
+	// - MySQL/MariaDB: Not typically used (schema IS the database)
+	// - MongoDB: Not used (no schema concept)
+	// - Others: Consult database documentation
 	Schema   string            `json:"schema,omitempty" yaml:"schema,omitempty"`
 	Advanced map[string]string `json:"advanced,omitempty" yaml:"advanced,omitempty"`
 }

--- a/cli/internal/tui/browser_view.go
+++ b/cli/internal/tui/browser_view.go
@@ -431,10 +431,27 @@ func (v *BrowserView) loadTables() tea.Cmd {
 			}
 		}
 
-		// Use currentSchema if already set, otherwise auto-select
+		// Use currentSchema if already set, otherwise check for preferred schema from connection
 		schema := v.currentSchema
 		if schema == "" {
-			schema = selectBestSchema(schemas)
+			// Check if connection has a preferred schema
+			if conn.Schema != "" {
+				// Try to use the preferred schema if it exists
+				schemaExists := false
+				for _, s := range schemas {
+					if s == conn.Schema {
+						schemaExists = true
+						schema = conn.Schema
+						break
+					}
+				}
+				if !schemaExists {
+					// Fall back to auto-selection if preferred schema doesn't exist
+					schema = selectBestSchema(schemas)
+				}
+			} else {
+				schema = selectBestSchema(schemas)
+			}
 			v.currentSchema = schema
 		}
 

--- a/cli/internal/tui/connection_view.go
+++ b/cli/internal/tui/connection_view.go
@@ -161,6 +161,16 @@ func NewConnectionView(parent *MainModel) *ConnectionView {
 	dbInput.Cursor.Style = lipgloss.NewStyle().Foreground(styles.Primary)
 	inputs = append(inputs, dbInput)
 
+	// Schema name (optional)
+	schemaInput := textinput.New()
+	schemaInput.Placeholder = "public (optional)"
+	schemaInput.CharLimit = 50
+	schemaInput.Width = 40
+	schemaInput.PromptStyle = lipgloss.NewStyle().Foreground(styles.Primary)
+	schemaInput.TextStyle = lipgloss.NewStyle().Foreground(styles.Foreground)
+	schemaInput.Cursor.Style = lipgloss.NewStyle().Foreground(styles.Primary)
+	inputs = append(inputs, schemaInput)
+
 	mode := "list"
 	if len(parent.config.Connections) == 0 {
 		mode = "form"
@@ -343,7 +353,7 @@ func (v *ConnectionView) updateForm(msg tea.Msg) (*ConnectionView, tea.Cmd) {
 			return v, nil
 
 		case "left":
-			if v.focusIndex == 6 {
+			if v.focusIndex == 7 {
 				v.dbTypeIndex--
 				if v.dbTypeIndex < 0 {
 					v.dbTypeIndex = len(v.dbTypes) - 1
@@ -353,7 +363,7 @@ func (v *ConnectionView) updateForm(msg tea.Msg) (*ConnectionView, tea.Cmd) {
 			return v, nil
 
 		case "right":
-			if v.focusIndex == 6 {
+			if v.focusIndex == 7 {
 				v.dbTypeIndex++
 				if v.dbTypeIndex >= len(v.dbTypes) {
 					v.dbTypeIndex = 0
@@ -363,7 +373,7 @@ func (v *ConnectionView) updateForm(msg tea.Msg) (*ConnectionView, tea.Cmd) {
 			return v, nil
 
 		case "enter":
-			if v.focusIndex == 7 {
+			if v.focusIndex == 8 {
 				// If password is empty, prompt securely before connecting
 				if v.inputs[4].Value() == "" {
 					v.awaitingPassword = true
@@ -504,9 +514,21 @@ func (v *ConnectionView) renderForm() string {
 	b.WriteString(v.inputs[5].View())
 	b.WriteString("\n\n")
 
-	// Database Type (index 6)
-	label = "Database Type:"
+	// Schema (index 6)
+	label = "Schema:"
 	if v.focusIndex == 6 {
+		label = styles.KeyStyle.Render("▶ " + label)
+	} else {
+		label = "  " + label
+	}
+	b.WriteString(label)
+	b.WriteString("\n  ")
+	b.WriteString(v.inputs[6].View())
+	b.WriteString("\n\n")
+
+	// Database Type (index 7)
+	label = "Database Type:"
+	if v.focusIndex == 7 {
 		label = styles.KeyStyle.Render("▶ " + label)
 	} else {
 		label = "  " + label
@@ -515,7 +537,7 @@ func (v *ConnectionView) renderForm() string {
 	b.WriteString("\n  ")
 	for i, dbType := range v.dbTypes {
 		if i == v.dbTypeIndex {
-			if v.focusIndex == 6 {
+			if v.focusIndex == 7 {
 				b.WriteString(styles.ActiveListItemStyle.Render(" " + dbType + " "))
 			} else {
 				b.WriteString(styles.KeyStyle.Render("[" + dbType + "]"))
@@ -527,9 +549,9 @@ func (v *ConnectionView) renderForm() string {
 	}
 	b.WriteString("\n\n")
 
-	// Connect button (index 7)
+	// Connect button (index 8)
 	connectBtn := "[Connect]"
-	if v.focusIndex == 7 {
+	if v.focusIndex == 8 {
 		connectBtn = styles.ActiveListItemStyle.Render(" Connect ")
 	} else {
 		connectBtn = styles.KeyStyle.Render(connectBtn)
@@ -585,7 +607,7 @@ func (v *ConnectionView) nextInput() {
 		v.inputs[v.focusIndex].Blur()
 	}
 	v.focusIndex++
-	if v.focusIndex > 7 {
+	if v.focusIndex > 8 {
 		v.focusIndex = 0
 	}
 	if v.focusIndex < len(v.inputs) {
@@ -599,7 +621,7 @@ func (v *ConnectionView) prevInput() {
 	}
 	v.focusIndex--
 	if v.focusIndex < 0 {
-		v.focusIndex = 7
+		v.focusIndex = 8
 	}
 	if v.focusIndex < len(v.inputs) {
 		v.inputs[v.focusIndex].Focus()
@@ -667,6 +689,7 @@ func (v *ConnectionView) connect() tea.Cmd {
 		username := v.inputs[3].Value()
 		password := v.inputs[4].Value()
 		database := v.inputs[5].Value()
+		schema := v.inputs[6].Value()
 		dbType := v.dbTypes[v.dbTypeIndex]
 
 		conn := config.Connection{
@@ -677,6 +700,7 @@ func (v *ConnectionView) connect() tea.Cmd {
 			Username: username,
 			Password: password,
 			Database: database,
+			Schema:   schema,
 		}
 
 		// Try to connect

--- a/cli/internal/tui/connection_view.go
+++ b/cli/internal/tui/connection_view.go
@@ -163,7 +163,7 @@ func NewConnectionView(parent *MainModel) *ConnectionView {
 
 	// Schema name (optional)
 	schemaInput := textinput.New()
-	schemaInput.Placeholder = "public (optional)"
+	schemaInput.Placeholder = "Schema name (optional, DB-specific)"
 	schemaInput.CharLimit = 50
 	schemaInput.Width = 40
 	schemaInput.PromptStyle = lipgloss.NewStyle().Foreground(styles.Primary)


### PR DESCRIPTION
## Summary

Adds an optional schema field to the CLI connection form and command-line interface.

## Changes

- Added Schema field to Connection config struct
- Added schema text input to connection form (index 6)
- Updated form navigation to accommodate new field
- Modified browser view to use preferred schema from connection
- Added --schema flag to CLI connect command
- Falls back to smart schema selection if preferred schema doesn't exist

## Testing

- The schema field appears in the connection form between Database and Database Type
- Schema is saved to connection config when provided
- Browser view uses preferred schema when available
- CLI --schema flag works for command-line connections

Fixes #735

---

Generated with [Claude Code](https://claude.ai/code)) | [Branch: claude/issue-735-20251217-1707](https://github.com/clidey/whodb/tree/claude/issue-735-20251217-1707) | [View job run](https://github.com/clidey/whodb/actions/runs/20310997842