### PR TITLE
feat(cli): add clear keyboard shortcuts for AI chat navigation

### DIFF
--- a/cli/internal/tui/chat_view.go
+++ b/cli/internal/tui/chat_view.go
@@ -255,6 +255,18 @@ func (v *ChatView) Update(msg tea.Msg) (*ChatView, tea.Cmd) {
 			v.parent.mode = ViewBrowser
 			return v, nil
 
+		case "ctrl+i", "/":
+			// Focus chat input
+			v.focusField = focusFieldMessage
+			v.input.Focus()
+			return v, nil
+
+		case "ctrl+p":
+			// Focus provider/model config section
+			v.focusField = focusFieldProvider
+			v.input.Blur()
+			return v, nil
+
 		case "ctrl+f":
 			v.focusField = (v.focusField + 1) % 3
 			if v.focusField == focusFieldMessage {
@@ -602,7 +614,8 @@ func (v *ChatView) View() string {
 		"[v]", "view table",
 		"scroll", "trackpad/mouse",
 		"enter", "send",
-		"ctrl+f", "focus field",
+		"ctrl+i / /", "focus input",
+		"ctrl+p", "focus config",
 		"←/→", "change selection",
 		"ctrl+l", "load models",
 		"ctrl+r", "revoke consent",


### PR DESCRIPTION
Resolves #741

## Changes
- Add Ctrl+I and / shortcuts to focus chat input directly
- Add Ctrl+P shortcut to focus provider/model config section
- Update help text to show new shortcuts
- Resolves confusion around chat navigation by providing explicit shortcuts

This implements the keyboard shortcuts for the CLI (not the web app) to provide clear, unambiguous navigation in the AI chat interface.

🤖 Generated with [Claude Code](https://claude.ai/code)