### PR TITLE
fix: prevent backend logs from leaking to AI chat in TUI

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -24,6 +24,8 @@ import (
 )
 
 func init() {
+	// Disable all logging output to prevent logs from leaking into TUI
+	log.DisableOutput()
 	log.SetLogLevel("none")
 }
 

--- a/core/src/log/log.go
+++ b/core/src/log/log.go
@@ -15,6 +15,7 @@
 package log
 
 import (
+	"io"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -113,6 +114,13 @@ func (c *ConditionalLogger) Warn(args ...any) {
 	c.Logger.Warn(args...)
 }
 
+func (c *ConditionalLogger) Warnf(format string, args ...any) {
+	if !isLevelEnabled("warning") {
+		return
+	}
+	c.Logger.Warnf(format, args...)
+}
+
 func (c *ConditionalLogger) Info(args ...any) {
 	if !isLevelEnabled("info") {
 		return
@@ -164,4 +172,12 @@ func LogFields(fields Fields) *ConditionalEntry {
 
 func SetLogLevel(level string) {
 	logLevel = level
+}
+
+// DisableOutput redirects all log output to io.Discard, preventing any logs from appearing in stdout/stderr.
+// This is useful for TUI applications where stdout is used for terminal rendering.
+func DisableOutput() {
+	if Logger != nil {
+		Logger.SetOutput(io.Discard)
+	}
 }


### PR DESCRIPTION
## Summary

Fixed issue where backend INFO logs were appearing in the AI chat interface in the TUI.

## Changes

- Added `DisableOutput()` function to log package to redirect output to `io.Discard`
- Updated CLI initialization to call `DisableOutput()` to prevent logs from interfering with TUI
- Added missing `Warnf()` method to ConditionalLogger for consistency

## Root Cause

The logrus logger was outputting to stdout by default, which in TUI applications is used for terminal rendering. This caused log messages to appear as text in the chat interface.

Fixes #734

Generated with [Claude Code](https://claude.ai/code)