### PR TITLE
feat(core,frontend): raw query export

### DIFF
--- a/frontend/src/components/export.tsx
+++ b/frontend/src/components/export.tsx
@@ -44,6 +44,7 @@ interface IExportProps {
     selectedRowsData?: Record<string, any>[];
     checkedRowsCount: number;
     databaseType?: string;
+    rawQuery?: string;
 }
 
 export const Export: FC<IExportProps> = ({
@@ -55,6 +56,7 @@ export const Export: FC<IExportProps> = ({
                                              selectedRowsData,
                                              checkedRowsCount,
                                              databaseType,
+                                             rawQuery,
                                          }) => {
     const { t } = useTranslation('components/export');
     const [exportDelimiter, setExportDelimiter] = useState(',');
@@ -93,7 +95,8 @@ export const Export: FC<IExportProps> = ({
         hasSelectedRows,
         exportDelimiter,
         selectedRowsForExport,
-        exportFormat
+        exportFormat,
+        rawQuery
     );
 
     const handleExportConfirm = useCallback(async () => {
@@ -118,7 +121,7 @@ export const Export: FC<IExportProps> = ({
                             <p>
                                 {hasSelectedRows
                                     ? t('selectedRows', { count: checkedRowsCount })
-                                    : t('allData')}
+                                    : rawQuery ? t('allDataRawQuery') : t('allData')}
                             </p>
                             <div className="mb-4 flex flex-col gap-2">
                                 <Label>

--- a/frontend/src/components/hooks.tsx
+++ b/frontend/src/components/hooks.tsx
@@ -20,7 +20,7 @@ import {isDesktopApp} from "../utils/external-links";
 import {addAuthHeader} from "../utils/auth-headers";
 
 
-export const useExportToCSV = (schema: string, storageUnit: string, selectedOnly: boolean = false, delimiter: string = ',', selectedRows?: Record<string, any>[], format: 'csv' | 'excel' | 'ndjson' = 'csv') => {
+export const useExportToCSV = (schema: string, storageUnit: string, selectedOnly: boolean = false, delimiter: string = ',', selectedRows?: Record<string, any>[], format: 'csv' | 'excel' | 'ndjson' = 'csv', rawQuery?: string) => {
     return useCallback(async () => {
       try {
         // Prepare request body
@@ -30,6 +30,10 @@ export const useExportToCSV = (schema: string, storageUnit: string, selectedOnly
           delimiter,
           format,
         };
+
+        if (rawQuery) {
+          requestBody.rawQuery = rawQuery;
+        }
 
         // Add selected rows if provided
         // For now, we'll use the full row data approach for selections
@@ -62,7 +66,7 @@ export const useExportToCSV = (schema: string, storageUnit: string, selectedOnly
         const contentDisposition = response.headers.get('Content-Disposition');
         // Only include schema in filename if it exists (for SQLite, schema is empty)
         const extension = format === 'excel' ? 'xlsx' : format === 'ndjson' ? 'ndjson' : 'csv';
-        let filename = schema ? `${schema}_${storageUnit}.${extension}` : `${storageUnit}.${extension}`;
+        let filename = rawQuery ? `query_export.${extension}` : schema ? `${schema}_${storageUnit}.${extension}` : `${storageUnit}.${extension}`;
         if (contentDisposition) {
           const filenameMatch = contentDisposition.match(/filename="(.+)"/);
           if (filenameMatch) {
@@ -104,7 +108,7 @@ export const useExportToCSV = (schema: string, storageUnit: string, selectedOnly
       } catch (error) {
         throw error;
       }
-    }, [schema, storageUnit, selectedOnly, delimiter, selectedRows, format]);
+    }, [schema, storageUnit, selectedOnly, delimiter, selectedRows, format, rawQuery]);
 };
 
 type ILongPressProps = {

--- a/frontend/src/components/table.tsx
+++ b/frontend/src/components/table.tsx
@@ -117,6 +117,7 @@ const DynamicExport: FC<{
     selectedRowsData?: Record<string, any>[];
     checkedRowsCount: number;
     databaseType?: string;
+    rawQuery?: string;
 }> = (props) => {
     // Use EE Export if available, otherwise fall back to CE Export
     const ExportComponent = EEExport || Export;
@@ -290,6 +291,7 @@ interface TableProps {
     databaseType?: string;
     // Mock data generation control - set to false for views/materialized views
     isMockDataGenerationAllowed?: boolean;
+    rawQuery?: string;
 }
 
 export const StorageUnitTable: FC<TableProps> = ({
@@ -322,6 +324,7 @@ export const StorageUnitTable: FC<TableProps> = ({
     databaseType,
     // Mock data generation control
     isMockDataGenerationAllowed = true,
+    rawQuery,
 }) => {
     const { t } = useTranslation('components/table');
     const [editIndex, setEditIndex] = useState<number | null>(null);
@@ -1735,6 +1738,7 @@ export const StorageUnitTable: FC<TableProps> = ({
                     selectedRowsData={selectedRowsData}
                     checkedRowsCount={checked.length}
                     databaseType={databaseType}
+                    rawQuery={rawQuery}
                 />
             </Suspense>
         </div>

--- a/frontend/src/locales/components/export.yaml
+++ b/frontend/src/locales/components/export.yaml
@@ -2,6 +2,7 @@ en:
   title: Export Data
   selectedRows: You are about to export {{count}} selected rows.
   allData: You are about to export all data from the table. This may take some time for large tables.
+  allDataRawQuery: You are about to export the results of your query.
   format: Format
   delimiter: Delimiter
   delimiterHelp: Choose a delimiter that doesn't appear in your data

--- a/frontend/src/pages/chat/chat.tsx
+++ b/frontend/src/pages/chat/chat.tsx
@@ -195,6 +195,7 @@ const TablePreview: FC<{ type: string, data: TableData, text: string }> = ({ typ
                             disableEdit={true}
                             limitContextMenu={true}
                             databaseType={current?.Type}
+                            rawQuery={text}
                         />
                     </div>
                     : (type.startsWith("sql:") && (type === "sql:insert" || type === "sql:update" || type === "sql:delete" || type === "sql:create" || type === "sql:alter" || type === "sql:drop"))

--- a/frontend/src/pages/raw-execute/query-view.tsx
+++ b/frontend/src/pages/raw-execute/query-view.tsx
@@ -93,6 +93,7 @@ export const QueryView: FC<IPluginProps> = ({ code, handleExecuteRef }) => {
                             limitContextMenu={true}
                             height={250}
                             databaseType={current?.Type}
+                            rawQuery={code}
                         />
                     )
                 }


### PR DESCRIPTION
Closes https://github.com/clidey/whodb/issues/795

- pass raw query from the app when exporting from chat/scratchpad;
- execute raw query on BE an provide an export file;

This is a vibe-coded implementation - there is some duplication with view export function and also it's inconsistent with how view export is done (where it's done through a plugin that accepts a writer), but moving raw query export into a plugin may not be preferred since raw query execution is already provided by a plugin, so we're just implementing writer the same way we do with view export.

I manually tested the changes with a Postgres db.