### PR TITLE
release

### DIFF
--- a/cli/internal/database/manager.go
+++ b/cli/internal/database/manager.go
@@ -695,6 +695,30 @@ func runWithContext[T any](ctx context.Context, fn func() (T, error)) (T, error)
 	}
 }
 
+// ExecuteExplain prepends the appropriate EXPLAIN prefix for the current
+// database type and executes the resulting query. The raw result is returned
+// so callers can display the plan output.
+func (m *Manager) ExecuteExplain(query string) (*engine.GetRowsResult, error) {
+	if m.currentConnection == nil {
+		return nil, fmt.Errorf("not connected to any database")
+	}
+
+	dbType := strings.ToLower(m.currentConnection.Type)
+	var explainQuery string
+	switch dbType {
+	case "postgres":
+		explainQuery = "EXPLAIN ANALYZE " + query
+	case "mysql", "mariadb", "sqlite3":
+		explainQuery = "EXPLAIN " + query
+	case "clickhouse":
+		explainQuery = "EXPLAIN PIPELINE " + query
+	default:
+		explainQuery = "EXPLAIN " + query
+	}
+
+	return m.ExecuteQuery(explainQuery)
+}
+
 // ExecuteQueryWithContext executes a query with context support for cancellation and timeout.
 // If the context is cancelled or times out, the function returns immediately with ctx.Err().
 // Note: The underlying database operation may continue running; only the wait is cancelled.

--- a/cli/internal/tui/editor_view.go
+++ b/cli/internal/tui/editor_view.go
@@ -195,6 +195,17 @@ func (v *EditorView) Update(msg tea.Msg) (*EditorView, tea.Cmd) {
 			return v, v.executeQuery()
 		}
 
+		// Ctrl+X to run EXPLAIN on current query
+		if msg.String() == "ctrl+x" {
+			query := v.textarea.Value()
+			if query != "" {
+				v.parent.explainView.query = query
+				v.parent.PushView(ViewExplain)
+				return v, v.runExplain(query)
+			}
+			return v, nil
+		}
+
 		// Ctrl+Space to manually trigger autocomplete
 		// Ctrl+@ is how Ctrl+Space is typically represented in terminals (ASCII 0)
 		if msg.Type == tea.KeyCtrlAt {
@@ -425,6 +436,7 @@ func (v *EditorView) View() string {
 		b.WriteString("\n\n")
 		bindings := []key.Binding{
 			Keys.Editor.Execute,
+			Keys.Editor.Explain,
 			Keys.Editor.Autocomplete,
 			Keys.Editor.Format,
 			Keys.Editor.OpenEditor,
@@ -691,4 +703,24 @@ func (v *EditorView) openExternalEditor() tea.Cmd {
 		}
 		return externalEditorResultMsg{content: string(data)}
 	})
+}
+
+// runExplain returns a tea.Cmd that executes EXPLAIN on the given query
+// and sends the result as an explainResultMsg.
+func (v *EditorView) runExplain(query string) tea.Cmd {
+	mgr := v.parent.dbManager
+	return func() tea.Msg {
+		result, err := mgr.ExecuteExplain(query)
+		if err != nil {
+			return explainResultMsg{query: query, err: err}
+		}
+
+		// Flatten result rows into a single plan string
+		var lines []string
+		for _, row := range result.Rows {
+			lines = append(lines, strings.Join(row, " "))
+		}
+		plan := strings.Join(lines, "\n")
+		return explainResultMsg{query: query, plan: plan}
+	}
 }

--- a/cli/internal/tui/erd_explain_test.go
+++ b/cli/internal/tui/erd_explain_test.go
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2025 Clidey, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/clidey/whodb/cli/internal/config"
+	"github.com/clidey/whodb/core/src/engine"
+
+	_ "github.com/clidey/whodb/core/src/plugins/sqlite3"
+)
+
+func setupConnectedModelForTest(t *testing.T) *MainModel {
+	t.Helper()
+	setupTestEnv(t)
+	os.Setenv("WHODB_CLI", "true")
+
+	tmpDir := t.TempDir()
+	dbPath := tmpDir + "/test.db"
+	f, err := os.Create(dbPath)
+	if err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	f.Close()
+
+	conn := &config.Connection{
+		Name: "test", Type: "Sqlite3", Host: dbPath, Database: dbPath,
+	}
+	m := NewMainModelWithConnection(conn)
+	if m.err != nil {
+		t.Skipf("SQLite not available: %v", m.err)
+	}
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	_, err = m.dbManager.ExecuteQuery("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)")
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	_, err = m.dbManager.ExecuteQuery("CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, total REAL)")
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	return m
+}
+
+func strPtr(s string) *string { return &s }
+
+// --- ERD Tests ---
+
+func TestERDView_TabCyclesTables(t *testing.T) {
+	m := setupConnectedModelForTest(t)
+
+	m.mode = ViewERD
+	m.erdView.loading = false
+	m.erdView.tables = []tableWithColumns{
+		{StorageUnit: engine.StorageUnit{Name: "users"}, Columns: []engine.Column{{Name: "id"}}},
+		{StorageUnit: engine.StorageUnit{Name: "orders"}, Columns: []engine.Column{{Name: "id"}}},
+	}
+
+	if m.erdView.focusedIndex != 0 {
+		t.Fatalf("initial focusedIndex should be 0, got %d", m.erdView.focusedIndex)
+	}
+
+	// Tab should cycle to next table, NOT switch views
+	m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if m.erdView.focusedIndex != 1 {
+		t.Errorf("After Tab: focusedIndex should be 1, got %d", m.erdView.focusedIndex)
+	}
+	if m.mode != ViewERD {
+		t.Errorf("After Tab: should still be in ViewERD, got %d", m.mode)
+	}
+
+	// Tab again wraps
+	m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if m.erdView.focusedIndex != 0 {
+		t.Errorf("After Tab2: focusedIndex should wrap to 0, got %d", m.erdView.focusedIndex)
+	}
+}
+
+func TestERDView_ZoomToggle(t *testing.T) {
+	m := setupConnectedModelForTest(t)
+
+	m.mode = ViewERD
+	m.erdView.loading = false
+	m.erdView.tables = []tableWithColumns{
+		{StorageUnit: engine.StorageUnit{Name: "users"}, Columns: []engine.Column{{Name: "id", Type: "INTEGER"}}},
+	}
+
+	if m.erdView.compact {
+		t.Fatal("should start expanded")
+	}
+
+	m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
+	if !m.erdView.compact {
+		t.Error("should be compact after z")
+	}
+
+	m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
+	if m.erdView.compact {
+		t.Error("should be expanded after second z")
+	}
+}
+
+func TestERDView_EscCloses(t *testing.T) {
+	m := setupConnectedModelForTest(t)
+
+	m.PushView(ViewERD)
+	if m.mode != ViewERD {
+		t.Fatal("should be in ViewERD")
+	}
+
+	m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.mode == ViewERD {
+		t.Error("Esc should close ERD view")
+	}
+}
+
+func TestERDView_RenderDoesNotPanic(t *testing.T) {
+	m := setupConnectedModelForTest(t)
+
+	m.mode = ViewERD
+	m.erdView.loading = false
+	m.erdView.tables = []tableWithColumns{
+		{
+			StorageUnit: engine.StorageUnit{Name: "users"},
+			Columns: []engine.Column{
+				{Name: "id", Type: "INTEGER", IsPrimary: true},
+				{Name: "name", Type: "TEXT"},
+			},
+		},
+		{
+			StorageUnit: engine.StorageUnit{Name: "orders"},
+			Columns: []engine.Column{
+				{Name: "id", Type: "INTEGER", IsPrimary: true},
+				{Name: "user_id", Type: "INTEGER", IsForeignKey: true, ReferencedTable: strPtr("users"), ReferencedColumn: strPtr("id")},
+			},
+		},
+	}
+
+	output := m.erdView.View()
+	if output == "" {
+		t.Error("ERD View() should produce output")
+	}
+	if !strings.Contains(output, "users") {
+		t.Error("output should contain 'users' table")
+	}
+}
+
+func TestERDLayout_RenderExpandedBox(t *testing.T) {
+	table := tableWithColumns{
+		StorageUnit: engine.StorageUnit{Name: "test_table"},
+		Columns: []engine.Column{
+			{Name: "id", Type: "INTEGER", IsPrimary: true},
+			{Name: "name", Type: "TEXT"},
+		},
+	}
+
+	box := renderTableBox(table, false, false)
+	if !strings.Contains(box.content, "test_table") {
+		t.Error("box should contain table name")
+	}
+	if !strings.Contains(box.content, "id") {
+		t.Error("box should contain column 'id'")
+	}
+	if !strings.Contains(box.content, "PK") {
+		t.Error("box should show PK for primary key")
+	}
+}
+
+func TestERDLayout_CompactBox(t *testing.T) {
+	table := tableWithColumns{
+		StorageUnit: engine.StorageUnit{Name: "users"},
+		Columns: []engine.Column{
+			{Name: "id", Type: "INTEGER"},
+		},
+	}
+
+	box := renderTableBox(table, true, false)
+	if !strings.Contains(box.content, "users") {
+		t.Error("compact box should contain table name")
+	}
+	if strings.Contains(box.content, "INTEGER") {
+		t.Error("compact box should not show column types")
+	}
+}
+
+// --- EXPLAIN Tests ---
+
+func TestExplainView_ReceivesResult(t *testing.T) {
+	m := setupConnectedModelForTest(t)
+	m.mode = ViewExplain
+	m.explainView.query = "SELECT * FROM users"
+
+	msg := explainResultMsg{
+		query: "SELECT * FROM users",
+		plan:  "SCAN users\n  SEARCH TABLE users",
+	}
+	m.Update(msg)
+
+	output := m.explainView.View()
+	if !strings.Contains(output, "SCAN") || !strings.Contains(output, "users") {
+		t.Errorf("Explain view should show the plan, got: %s", output)
+	}
+}
+
+func TestExplainView_HandlesError(t *testing.T) {
+	m := setupConnectedModelForTest(t)
+	m.mode = ViewExplain
+
+	msg := explainResultMsg{
+		query: "SELECT * FROM nonexistent",
+		err:   fmt.Errorf("no such table: nonexistent"),
+	}
+	m.Update(msg)
+
+	output := m.explainView.View()
+	if !strings.Contains(output, "nonexistent") {
+		t.Error("should show the error message")
+	}
+}
+
+func TestExplainView_EscCloses(t *testing.T) {
+	m := setupConnectedModelForTest(t)
+
+	m.PushView(ViewExplain)
+	if m.mode != ViewExplain {
+		t.Fatal("should be in ViewExplain")
+	}
+
+	m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.mode == ViewExplain {
+		t.Error("Esc should close Explain view")
+	}
+}
+
+func TestExplainKeybinding(t *testing.T) {
+	help := Keys.Editor.Explain.Help()
+	if help.Key != "ctrl+x" {
+		t.Errorf("Explain key should be 'ctrl+x', got %q", help.Key)
+	}
+}
+
+func TestExecuteExplain_SQLite(t *testing.T) {
+	m := setupConnectedModelForTest(t)
+
+	result, err := m.dbManager.ExecuteExplain("SELECT * FROM users")
+	if err != nil {
+		t.Fatalf("ExecuteExplain: %v", err)
+	}
+	if result == nil || len(result.Rows) == 0 {
+		t.Error("EXPLAIN should return rows")
+	}
+}

--- a/cli/internal/tui/erd_layout.go
+++ b/cli/internal/tui/erd_layout.go
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2025 Clidey, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/clidey/whodb/cli/pkg/styles"
+	"github.com/clidey/whodb/core/src/engine"
+)
+
+// erdTableBox holds the rendered box for a single table and its position on the canvas.
+type erdTableBox struct {
+	name    string
+	content string
+	width   int
+	height  int
+	x       int
+	y       int
+}
+
+// renderTableBox renders a single table as a Unicode box-drawing box.
+// If compact is true, only the table name header is shown (no columns).
+func renderTableBox(table tableWithColumns, compact bool, focused bool) erdTableBox {
+	name := table.StorageUnit.Name
+
+	if compact {
+		return renderCompactBox(name, focused)
+	}
+
+	return renderExpandedBox(name, table.Columns, focused)
+}
+
+// renderCompactBox renders a minimal table box with only the name.
+func renderCompactBox(name string, focused bool) erdTableBox {
+	// Compact: just header row
+	inner := " " + name + " "
+	boxWidth := len(inner) + 2 // +2 for left/right border chars
+
+	borderColor := styles.Muted
+	if focused {
+		borderColor = styles.Primary
+	}
+
+	borderStyle := lipgloss.NewStyle().Foreground(borderColor)
+	nameStyle := lipgloss.NewStyle().Foreground(styles.Primary).Bold(true)
+
+	top := borderStyle.Render("┌─") + nameStyle.Render(name) + borderStyle.Render(" "+strings.Repeat("─", 1)+"┐")
+	bottom := borderStyle.Render("└" + strings.Repeat("─", boxWidth-2) + "┘")
+
+	content := top + "\n" + bottom
+	renderedWidth := lipgloss.Width(top)
+
+	return erdTableBox{
+		name:    name,
+		content: content,
+		width:   renderedWidth,
+		height:  2,
+	}
+}
+
+// renderExpandedBox renders a full table box with columns listed inside.
+func renderExpandedBox(name string, columns []engine.Column, focused bool) erdTableBox {
+	borderColor := styles.Muted
+	if focused {
+		borderColor = styles.Primary
+	}
+
+	borderStyle := lipgloss.NewStyle().Foreground(borderColor)
+	nameStyle := lipgloss.NewStyle().Foreground(styles.Primary).Bold(true)
+	colNameStyle := lipgloss.NewStyle().Foreground(styles.Foreground)
+	colTypeStyle := lipgloss.NewStyle().Foreground(styles.Muted)
+	pkStyle := lipgloss.NewStyle().Foreground(styles.Success)
+	fkStyle := lipgloss.NewStyle().Foreground(styles.Info)
+
+	// Build column lines to determine max width
+	type colLine struct {
+		plain  string // for width calculation (no ANSI)
+		styled string
+	}
+
+	var lines []colLine
+	for _, col := range columns {
+		var badges string
+		if col.IsPrimary {
+			badges += " [PK]"
+		}
+		if col.IsForeignKey && col.ReferencedTable != nil && col.ReferencedColumn != nil {
+			badges += fmt.Sprintf(" [FK]->%s.%s", *col.ReferencedTable, *col.ReferencedColumn)
+		} else if col.IsForeignKey {
+			badges += " [FK]"
+		}
+
+		plain := fmt.Sprintf(" %s: %s%s ", col.Name, col.Type, badges)
+
+		// Build styled version
+		styled := " " + colNameStyle.Render(col.Name) + colTypeStyle.Render(": "+col.Type)
+		if col.IsPrimary {
+			styled += pkStyle.Render(" [PK]")
+		}
+		if col.IsForeignKey && col.ReferencedTable != nil && col.ReferencedColumn != nil {
+			styled += fkStyle.Render(fmt.Sprintf(" [FK]->%s.%s", *col.ReferencedTable, *col.ReferencedColumn))
+		} else if col.IsForeignKey {
+			styled += fkStyle.Render(" [FK]")
+		}
+		styled += " "
+
+		lines = append(lines, colLine{plain: plain, styled: styled})
+	}
+
+	// Determine box inner width
+	minWidth := len(name) + 4 // "─ name ─" needs at least this
+	maxLineWidth := minWidth
+	for _, l := range lines {
+		if len(l.plain) > maxLineWidth {
+			maxLineWidth = len(l.plain)
+		}
+	}
+	innerWidth := maxLineWidth
+
+	// Render top border: ┌─ name ──...─┐
+	headerPad := innerWidth - len(name) - 2 // -2 for "─ " before name, " " after
+	if headerPad < 1 {
+		headerPad = 1
+	}
+	top := borderStyle.Render("┌─") + " " + nameStyle.Render(name) + " " + borderStyle.Render(strings.Repeat("─", headerPad)+"┐")
+
+	// Render column rows
+	var rowStrings []string
+	rowStrings = append(rowStrings, top)
+	for _, l := range lines {
+		pad := innerWidth - len(l.plain)
+		if pad < 0 {
+			pad = 0
+		}
+		row := borderStyle.Render("│") + l.styled + strings.Repeat(" ", pad) + borderStyle.Render("│")
+		rowStrings = append(rowStrings, row)
+	}
+
+	// If no columns, show an empty row
+	if len(lines) == 0 {
+		emptyText := styles.MutedStyle.Render(" (no columns) ")
+		pad := innerWidth - len(" (no columns) ")
+		if pad < 0 {
+			pad = 0
+		}
+		row := borderStyle.Render("│") + emptyText + strings.Repeat(" ", pad) + borderStyle.Render("│")
+		rowStrings = append(rowStrings, row)
+	}
+
+	// Bottom border
+	bottom := borderStyle.Render("└" + strings.Repeat("─", innerWidth) + "┘")
+	rowStrings = append(rowStrings, bottom)
+
+	content := strings.Join(rowStrings, "\n")
+	renderedWidth := lipgloss.Width(top)
+	renderedHeight := len(rowStrings)
+
+	return erdTableBox{
+		name:    name,
+		content: content,
+		width:   renderedWidth,
+		height:  renderedHeight,
+	}
+}
+
+// layoutERDGrid arranges table boxes in a grid layout that fits within the viewport width.
+// Returns the rendered boxes with x/y positions set, and the total canvas dimensions.
+func layoutERDGrid(tables []tableWithColumns, viewportWidth int, compact bool, focusedIndex int) ([]erdTableBox, int, int) {
+	if len(tables) == 0 {
+		return nil, 0, 0
+	}
+
+	const hGap = 3 // horizontal gap between boxes
+	const vGap = 1 // vertical gap between rows
+
+	// First pass: render all boxes to get their sizes
+	boxes := make([]erdTableBox, len(tables))
+	for i, table := range tables {
+		boxes[i] = renderTableBox(table, compact, i == focusedIndex)
+	}
+
+	// Second pass: arrange in rows
+	var rows [][]int // each row is a slice of box indices
+	var currentRow []int
+	rowWidth := 0
+
+	for i, box := range boxes {
+		neededWidth := box.width
+		if len(currentRow) > 0 {
+			neededWidth += hGap
+		}
+
+		if rowWidth+neededWidth > viewportWidth && len(currentRow) > 0 {
+			rows = append(rows, currentRow)
+			currentRow = []int{i}
+			rowWidth = box.width
+		} else {
+			currentRow = append(currentRow, i)
+			rowWidth += neededWidth
+		}
+	}
+	if len(currentRow) > 0 {
+		rows = append(rows, currentRow)
+	}
+
+	// Third pass: assign positions
+	canvasWidth := 0
+	canvasHeight := 0
+	y := 0
+
+	for _, row := range rows {
+		x := 0
+		rowHeight := 0
+
+		for j, idx := range row {
+			if j > 0 {
+				x += hGap
+			}
+			boxes[idx].x = x
+			boxes[idx].y = y
+			x += boxes[idx].width
+			if boxes[idx].height > rowHeight {
+				rowHeight = boxes[idx].height
+			}
+		}
+
+		if x > canvasWidth {
+			canvasWidth = x
+		}
+		y += rowHeight + vGap
+		canvasHeight = y
+	}
+
+	return boxes, canvasWidth, canvasHeight
+}
+
+// renderERDCanvas composites the table boxes onto a single string canvas.
+func renderERDCanvas(boxes []erdTableBox) string {
+	if len(boxes) == 0 {
+		return ""
+	}
+
+	// Find canvas dimensions
+	maxX := 0
+	maxY := 0
+	for _, box := range boxes {
+		right := box.x + box.width
+		bottom := box.y + box.height
+		if right > maxX {
+			maxX = right
+		}
+		if bottom > maxY {
+			maxY = bottom
+		}
+	}
+
+	// Build a 2D grid of strings (one per line)
+	// We use a simpler approach: render each box at its y offset,
+	// joining lines with appropriate x padding.
+	canvas := make([]string, maxY)
+	for i := range canvas {
+		canvas[i] = ""
+	}
+
+	// Place each box line by line
+	for _, box := range boxes {
+		lines := strings.Split(box.content, "\n")
+		for i, line := range lines {
+			row := box.y + i
+			if row >= len(canvas) {
+				break
+			}
+
+			// Ensure the canvas row is wide enough
+			currentWidth := lipgloss.Width(canvas[row])
+			if currentWidth < box.x {
+				canvas[row] += strings.Repeat(" ", box.x-currentWidth)
+			}
+			canvas[row] += line
+		}
+	}
+
+	return strings.Join(canvas, "\n")
+}

--- a/cli/internal/tui/erd_view.go
+++ b/cli/internal/tui/erd_view.go
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2025 Clidey, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/clidey/whodb/cli/pkg/styles"
+)
+
+// erdDataLoadedMsg is sent when the ERD data (tables + columns) has been loaded.
+type erdDataLoadedMsg struct {
+	tables []tableWithColumns
+	err    error
+	schema string
+}
+
+// ERDView renders an entity-relationship diagram using Unicode box-drawing characters.
+// It shows tables, their columns, and foreign key annotations. Accessible via Ctrl+K.
+type ERDView struct {
+	parent       *MainModel
+	tables       []tableWithColumns
+	loading      bool
+	err          error
+	compact      bool
+	focusedIndex int
+	viewport     viewport.Model
+	width        int
+	height       int
+	ready        bool
+	schema       string
+}
+
+// NewERDView creates a new ERDView attached to the given parent model.
+func NewERDView(parent *MainModel) *ERDView {
+	return &ERDView{
+		parent: parent,
+		width:  80,
+		height: 20,
+	}
+}
+
+// Update handles input and messages for the ERD view.
+func (v *ERDView) Update(msg tea.Msg) (*ERDView, tea.Cmd) {
+	switch msg := msg.(type) {
+	case erdDataLoadedMsg:
+		v.loading = false
+		if msg.err != nil {
+			v.err = msg.err
+			return v, nil
+		}
+		v.tables = msg.tables
+		v.schema = msg.schema
+		v.focusedIndex = 0
+		v.rebuildViewport()
+		return v, nil
+
+	case tea.WindowSizeMsg:
+		v.width = msg.Width
+		v.height = msg.Height
+		if !v.loading && v.err == nil {
+			v.rebuildViewport()
+		}
+		return v, nil
+
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, Keys.Global.Back):
+			if !v.parent.PopView() {
+				v.parent.mode = ViewBrowser
+			}
+			return v, nil
+
+		case key.Matches(msg, Keys.ERD.ToggleZoom):
+			v.compact = !v.compact
+			v.rebuildViewport()
+			return v, nil
+
+		case key.Matches(msg, Keys.ERD.NextTable):
+			if len(v.tables) > 0 {
+				v.focusedIndex = (v.focusedIndex + 1) % len(v.tables)
+				v.rebuildViewport()
+			}
+			return v, nil
+
+		case key.Matches(msg, Keys.ERD.PrevTable):
+			if len(v.tables) > 0 {
+				v.focusedIndex--
+				if v.focusedIndex < 0 {
+					v.focusedIndex = len(v.tables) - 1
+				}
+				v.rebuildViewport()
+			}
+			return v, nil
+		}
+	}
+
+	// Forward remaining messages (arrow keys, etc.) to the viewport for scrolling
+	var cmd tea.Cmd
+	v.viewport, cmd = v.viewport.Update(msg)
+	return v, cmd
+}
+
+// View renders the ERD view.
+func (v *ERDView) View() string {
+	var b strings.Builder
+
+	title := "ER Diagram"
+	if v.schema != "" {
+		title += " — " + v.schema
+	}
+	b.WriteString(styles.RenderTitle(title))
+	b.WriteString("\n\n")
+
+	if v.err != nil {
+		b.WriteString(styles.RenderErrorBox(v.err.Error()))
+		b.WriteString("\n\n")
+		b.WriteString(RenderBindingHelpWidth(v.width, Keys.Global.Back))
+		return lipgloss.NewStyle().Padding(1, 2).Render(b.String())
+	}
+
+	if v.loading {
+		b.WriteString(v.parent.SpinnerView() + styles.RenderMuted(" Loading tables..."))
+		b.WriteString("\n\n")
+		b.WriteString(RenderBindingHelpWidth(v.width, Keys.Global.Back))
+		return lipgloss.NewStyle().Padding(1, 2).Render(b.String())
+	}
+
+	if len(v.tables) == 0 {
+		b.WriteString(styles.RenderMuted("No tables found."))
+		b.WriteString("\n\n")
+		b.WriteString(RenderBindingHelpWidth(v.width, Keys.Global.Back))
+		return lipgloss.NewStyle().Padding(1, 2).Render(b.String())
+	}
+
+	// Table summary line
+	focusedName := ""
+	if v.focusedIndex >= 0 && v.focusedIndex < len(v.tables) {
+		focusedName = v.tables[v.focusedIndex].StorageUnit.Name
+	}
+	modeLabel := "expanded"
+	if v.compact {
+		modeLabel = "compact"
+	}
+	summary := fmt.Sprintf("%d tables (%s) — focused: %s", len(v.tables), modeLabel, focusedName)
+	b.WriteString(styles.RenderMuted(summary))
+	b.WriteString("\n\n")
+
+	// Viewport with the diagram
+	if !v.ready {
+		v.rebuildViewport()
+	}
+	b.WriteString(v.viewport.View())
+	b.WriteString("\n\n")
+
+	// Help bar
+	b.WriteString(RenderBindingHelpWidth(v.width,
+		Keys.ERD.NextTable,
+		Keys.ERD.PrevTable,
+		Keys.ERD.ToggleZoom,
+		Keys.ERD.ScrollUp,
+		Keys.ERD.ScrollDown,
+		Keys.Global.Back,
+	))
+
+	// Scroll percentage
+	if v.viewport.TotalLineCount() > v.viewport.VisibleLineCount() {
+		pct := v.viewport.ScrollPercent() * 100
+		var scrollPct string
+		if pct >= 99.5 {
+			scrollPct = "bottom"
+		} else {
+			scrollPct = fmt.Sprintf("%.0f%%", pct)
+		}
+		b.WriteString("  ")
+		b.WriteString(styles.RenderMuted(scrollPct))
+	}
+
+	return lipgloss.NewStyle().Padding(1, 2).Render(b.String())
+}
+
+// loadERDData returns a tea.Cmd that fetches all tables and their columns.
+func (v *ERDView) loadERDData() tea.Cmd {
+	browserSchema := v.parent.browserView.currentSchema
+
+	return func() tea.Msg {
+		conn := v.parent.dbManager.GetCurrentConnection()
+		if conn == nil {
+			return erdDataLoadedMsg{err: fmt.Errorf("no connection")}
+		}
+
+		schema := browserSchema
+		if schema == "" {
+			schemas, err := v.parent.dbManager.GetSchemas()
+			if err != nil {
+				schemas = []string{}
+			}
+			if len(schemas) > 0 {
+				schema = selectBestSchema(schemas)
+			}
+		}
+
+		units, err := v.parent.dbManager.GetStorageUnits(schema)
+		if err != nil {
+			return erdDataLoadedMsg{err: fmt.Errorf("failed to get tables: %w", err)}
+		}
+
+		var tables []tableWithColumns
+		for _, unit := range units {
+			columns, err := v.parent.dbManager.GetColumns(schema, unit.Name)
+			if err != nil {
+				continue
+			}
+			tables = append(tables, tableWithColumns{
+				StorageUnit: unit,
+				Columns:     columns,
+			})
+		}
+
+		return erdDataLoadedMsg{tables: tables, schema: schema}
+	}
+}
+
+// rebuildViewport re-renders the diagram and sets it as the viewport content.
+func (v *ERDView) rebuildViewport() {
+	contentWidth := v.width - 8
+	if contentWidth < 20 {
+		contentWidth = 20
+	}
+	contentHeight := v.height - 14
+	if contentHeight < 3 {
+		contentHeight = 3
+	}
+
+	boxes, _, _ := layoutERDGrid(v.tables, contentWidth, v.compact, v.focusedIndex)
+	canvas := renderERDCanvas(boxes)
+
+	v.viewport = viewport.New(contentWidth, contentHeight)
+	v.viewport.SetContent(canvas)
+	v.ready = true
+}

--- a/cli/internal/tui/explain_view.go
+++ b/cli/internal/tui/explain_view.go
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2025 Clidey, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tui
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/clidey/whodb/cli/pkg/styles"
+)
+
+// costPattern matches Postgres-style cost annotations like "cost=0.00..35.50".
+var costPattern = regexp.MustCompile(`cost=[\d.]+\.\.([\d.]+)`)
+
+// ExplainView displays the output of an EXPLAIN (ANALYZE) query in a
+// scrollable, color-coded viewport.
+type ExplainView struct {
+	parent   *MainModel
+	viewport viewport.Model
+	query    string
+	plan     string
+	width    int
+	height   int
+	ready    bool
+}
+
+// NewExplainView creates a new ExplainView attached to the given parent model.
+func NewExplainView(parent *MainModel) *ExplainView {
+	return &ExplainView{
+		parent: parent,
+	}
+}
+
+// Update handles input for the explain view.
+func (v *ExplainView) Update(msg tea.Msg) (*ExplainView, tea.Cmd) {
+	switch msg := msg.(type) {
+	case explainResultMsg:
+		if msg.err != nil {
+			v.SetPlan(msg.query, "Error: "+msg.err.Error())
+		} else {
+			v.SetPlan(msg.query, msg.plan)
+		}
+		return v, nil
+
+	case tea.WindowSizeMsg:
+		v.width = msg.Width
+		v.height = msg.Height
+		v.initViewport()
+		return v, nil
+
+	case tea.KeyMsg:
+		if key.Matches(msg, Keys.Global.Back) {
+			if !v.parent.PopView() {
+				v.parent.mode = ViewEditor
+			}
+			return v, nil
+		}
+	}
+
+	var cmd tea.Cmd
+	v.viewport, cmd = v.viewport.Update(msg)
+	return v, cmd
+}
+
+// View renders the explain view.
+func (v *ExplainView) View() string {
+	if !v.ready {
+		v.initViewport()
+	}
+
+	var b strings.Builder
+
+	b.WriteString(styles.RenderTitle("Query Plan"))
+	b.WriteString("\n\n")
+
+	// Show the query being explained
+	if v.query != "" {
+		truncated := v.query
+		maxLen := v.width - 12
+		if maxLen < 20 {
+			maxLen = 20
+		}
+		if len(truncated) > maxLen {
+			truncated = truncated[:maxLen] + "..."
+		}
+		b.WriteString(styles.RenderMuted(truncated))
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString(v.viewport.View())
+	b.WriteString("\n\n")
+
+	b.WriteString(RenderBindingHelpWidth(v.width,
+		key.NewBinding(key.WithKeys("up", "down"), key.WithHelp("up/dn", "scroll")),
+		Keys.Global.Back,
+	))
+
+	if v.viewport.TotalLineCount() > v.viewport.VisibleLineCount() {
+		pct := v.viewport.ScrollPercent() * 100
+		var scrollPct string
+		if pct >= 99.5 {
+			scrollPct = "bottom"
+		} else {
+			scrollPct = formatFloat(pct) + "%"
+		}
+		b.WriteString("  ")
+		b.WriteString(styles.RenderMuted(scrollPct))
+	}
+
+	return lipgloss.NewStyle().Padding(1, 2).Render(b.String())
+}
+
+// SetPlan stores the explain output and resets the viewport so it is
+// rebuilt on the next render pass.
+func (v *ExplainView) SetPlan(query, plan string) {
+	v.query = query
+	v.plan = plan
+	v.ready = false
+}
+
+// initViewport creates (or resizes) the viewport and fills it with the
+// color-coded plan text.
+func (v *ExplainView) initViewport() {
+	contentWidth := v.width - 8
+	if contentWidth < 20 {
+		contentWidth = 20
+	}
+	// Reserve space for title, query line, help footer, and padding
+	contentHeight := v.height - 14
+	if contentHeight < 3 {
+		contentHeight = 3
+	}
+
+	v.viewport = viewport.New(contentWidth, contentHeight)
+	v.viewport.SetContent(colorizePlan(v.plan))
+	v.ready = true
+}
+
+// colorizePlan applies color coding to EXPLAIN output. Lines containing a
+// Postgres-style cost annotation are colored green/yellow/red based on the
+// upper cost bound. Lines without cost information are rendered with the
+// default foreground color.
+func colorizePlan(plan string) string {
+	if strings.TrimSpace(plan) == "" {
+		return styles.MutedStyle.Render("(no plan output)")
+	}
+
+	lines := strings.Split(plan, "\n")
+	var out strings.Builder
+	for i, line := range lines {
+		if i > 0 {
+			out.WriteString("\n")
+		}
+		out.WriteString(colorizePlanLine(line))
+	}
+	return out.String()
+}
+
+// colorizePlanLine colors a single line of EXPLAIN output. If the line
+// contains a cost=...  annotation, the color is determined by the upper cost
+// bound: <100 green, 100-1000 yellow, >1000 red.
+func colorizePlanLine(line string) string {
+	matches := costPattern.FindStringSubmatch(line)
+	if len(matches) < 2 {
+		return line
+	}
+
+	cost, err := strconv.ParseFloat(matches[1], 64)
+	if err != nil {
+		return line
+	}
+
+	var color lipgloss.AdaptiveColor
+	switch {
+	case cost < 100:
+		color = styles.Success
+	case cost <= 1000:
+		color = styles.Warning
+	default:
+		color = styles.Error
+	}
+
+	return lipgloss.NewStyle().Foreground(color).Render(line)
+}

--- a/cli/internal/tui/keymap.go
+++ b/cli/internal/tui/keymap.go
@@ -30,6 +30,7 @@ type GlobalKeys struct {
 	Import      key.Binding
 	ReadOnly    key.Binding
 	CmdLog      key.Binding
+	ERDiagram   key.Binding
 }
 
 // BrowserKeys contains keybindings for the browser view
@@ -56,6 +57,7 @@ type EditorKeys struct {
 	Format       key.Binding
 	OpenEditor   key.Binding
 	Bookmarks    key.Binding
+	Explain      key.Binding
 	NewTab       key.Binding
 	CloseTab     key.Binding
 	PrevTab      key.Binding
@@ -179,6 +181,15 @@ type BookmarksKeys struct {
 	Delete key.Binding
 }
 
+// ERDKeys contains keybindings for the ER diagram view
+type ERDKeys struct {
+	NextTable  key.Binding
+	PrevTable  key.Binding
+	ToggleZoom key.Binding
+	ScrollUp   key.Binding
+	ScrollDown key.Binding
+}
+
 // SchemaSelectKeys contains keybindings for schema selection (browser)
 type SchemaSelectKeys struct {
 	NavLeft      key.Binding
@@ -204,6 +215,7 @@ type Keymap struct {
 	Filter         FilterKeys
 	SchemaSelect   SchemaSelectKeys
 	Bookmarks      BookmarksKeys
+	ERD            ERDKeys
 }
 
 // Keys is the top-level keymap containing all keybindings
@@ -244,6 +256,10 @@ var Keys = Keymap{
 		CmdLog: key.NewBinding(
 			key.WithKeys("ctrl+d"),
 			key.WithHelp("ctrl+d", "command log"),
+		),
+		ERDiagram: key.NewBinding(
+			key.WithKeys("ctrl+k"),
+			key.WithHelp("ctrl+k", "ER diagram"),
 		),
 	},
 	Browser: BrowserKeys{
@@ -320,6 +336,10 @@ var Keys = Keymap{
 		Bookmarks: key.NewBinding(
 			key.WithKeys("ctrl+b"),
 			key.WithHelp("ctrl+b", "bookmarks"),
+		),
+		Explain: key.NewBinding(
+			key.WithKeys("ctrl+x"),
+			key.WithHelp("ctrl+x", "explain"),
 		),
 		NewTab: key.NewBinding(
 			key.WithKeys("ctrl+n"),
@@ -648,6 +668,28 @@ var Keys = Keymap{
 		Delete: key.NewBinding(
 			key.WithKeys("d"),
 			key.WithHelp("[d]", "delete"),
+		),
+	},
+	ERD: ERDKeys{
+		NextTable: key.NewBinding(
+			key.WithKeys("tab"),
+			key.WithHelp("tab", "next table"),
+		),
+		PrevTable: key.NewBinding(
+			key.WithKeys("shift+tab"),
+			key.WithHelp("shift+tab", "prev table"),
+		),
+		ToggleZoom: key.NewBinding(
+			key.WithKeys("z"),
+			key.WithHelp("[z]", "toggle zoom"),
+		),
+		ScrollUp: key.NewBinding(
+			key.WithKeys("up", "k"),
+			key.WithHelp("↑/k", "scroll up"),
+		),
+		ScrollDown: key.NewBinding(
+			key.WithKeys("down", "j"),
+			key.WithHelp("↓/j", "scroll down"),
 		),
 	},
 }

--- a/cli/internal/tui/messages.go
+++ b/cli/internal/tui/messages.go
@@ -127,6 +127,13 @@ type themeChangedMsg struct {
 // escConfirmTimeoutMsg resets the Esc-to-disconnect confirmation after a timeout.
 type escConfirmTimeoutMsg struct{}
 
+// explainResultMsg is sent when an EXPLAIN query completes.
+type explainResultMsg struct {
+	query string
+	plan  string
+	err   error
+}
+
 // tableWithColumns pairs a storage unit with its column metadata
 type tableWithColumns struct {
 	StorageUnit engine.StorageUnit

--- a/cli/internal/tui/model.go
+++ b/cli/internal/tui/model.go
@@ -50,6 +50,8 @@ const (
 	ViewBookmarks
 	ViewJSON
 	ViewCmdLog
+	ViewExplain
+	ViewERD
 )
 
 type MainModel struct {
@@ -80,6 +82,8 @@ type MainModel struct {
 	bookmarksView  *BookmarksView
 	jsonViewer     *JSONViewer
 	cmdLogView     *CmdLogView
+	explainView    *ExplainView
+	erdView        *ERDView
 
 	// panes maps each ViewMode to its Pane interface for polymorphic layout dispatch.
 	panes map[ViewMode]Pane
@@ -133,6 +137,8 @@ func NewMainModel() *MainModel {
 	m.bookmarksView = NewBookmarksView(m)
 	m.jsonViewer = NewJSONViewer(m)
 	m.cmdLogView = NewCmdLogView(m)
+	m.explainView = NewExplainView(m)
+	m.erdView = NewERDView(m)
 
 	m.panes = map[ViewMode]Pane{
 		ViewConnection: m.connectionView,
@@ -149,6 +155,8 @@ func NewMainModel() *MainModel {
 		ViewBookmarks:  m.bookmarksView,
 		ViewJSON:       m.jsonViewer,
 		ViewCmdLog:     m.cmdLogView,
+		ViewExplain:    m.explainView,
+		ViewERD:        m.erdView,
 	}
 
 	return m
@@ -243,6 +251,8 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.whereView, _ = m.whereView.Update(msg)
 		m.jsonViewer, _ = m.jsonViewer.Update(msg)
 		m.cmdLogView, _ = m.cmdLogView.Update(msg)
+		m.explainView, _ = m.explainView.Update(msg)
+		m.erdView, _ = m.erdView.Update(msg)
 
 		// Rebuild layout on resize if connected
 		if m.dbManager.GetCurrentConnection() != nil && m.layoutRoot == nil {
@@ -343,6 +353,16 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 
+		case "ctrl+k":
+			// Global shortcut: open ER diagram
+			if m.dbManager.GetCurrentConnection() != nil && m.mode != ViewERD {
+				m.suspendLayout()
+				m.erdView.loading = true
+				m.erdView.err = nil
+				m.PushView(ViewERD)
+				return m, m.erdView.loadERDData()
+			}
+
 		case "ctrl+a":
 			// Global shortcut: open AI Chat from any view/pane
 			if m.dbManager.GetCurrentConnection() != nil && m.mode != ViewChat {
@@ -352,6 +372,10 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case "tab", "shift+tab":
+			// Let modal views handle Tab themselves (e.g., ERD table cycling)
+			if m.mode == ViewERD {
+				return m.updateERDView(msg)
+			}
 			// Let connection view handle Tab for its own navigation
 			if m.mode == ViewConnection {
 				return m.updateConnectionView(msg)
@@ -395,6 +419,10 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateConnectionView(msg)
 	case importResultMsg, importPreviewMsg:
 		return m.updateImportView(msg)
+	case explainResultMsg:
+		return m.updateExplainView(msg)
+	case erdDataLoadedMsg:
+		return m.updateERDView(msg)
 	}
 
 	switch m.mode {
@@ -426,6 +454,10 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateJSONViewer(msg)
 	case ViewCmdLog:
 		return m.updateCmdLogView(msg)
+	case ViewExplain:
+		return m.updateExplainView(msg)
+	case ViewERD:
+		return m.updateERDView(msg)
 	}
 
 	return m, nil
@@ -440,6 +472,18 @@ func (m *MainModel) updateJSONViewer(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m *MainModel) updateCmdLogView(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	m.cmdLogView, cmd = m.cmdLogView.Update(msg)
+	return m, cmd
+}
+
+func (m *MainModel) updateExplainView(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.explainView, cmd = m.explainView.Update(msg)
+	return m, cmd
+}
+
+func (m *MainModel) updateERDView(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.erdView, cmd = m.erdView.Update(msg)
 	return m, cmd
 }
 
@@ -509,6 +553,10 @@ func (m *MainModel) View() string {
 			content = m.jsonViewer.View()
 		case ViewCmdLog:
 			content = m.cmdLogView.View()
+		case ViewExplain:
+			content = m.explainView.View()
+		case ViewERD:
+			content = m.erdView.View()
 		}
 	}
 
@@ -552,7 +600,8 @@ func (m *MainModel) isLoading() bool {
 		m.schemaView.loading ||
 		m.historyView.executing ||
 		m.connectionView.connecting ||
-		m.resultsView.loading
+		m.resultsView.loading ||
+		m.erdView.loading
 }
 
 // renderStatusBar renders the persistent status bar shown when connected.
@@ -607,7 +656,7 @@ func (m *MainModel) renderStatusBar() string {
 // isHelpSafe returns true if it's safe to show help (no active text input)
 func (m *MainModel) isHelpSafe() bool {
 	switch m.mode {
-	case ViewResults, ViewHistory, ViewColumns, ViewSchema, ViewJSON, ViewBookmarks, ViewCmdLog:
+	case ViewResults, ViewHistory, ViewColumns, ViewSchema, ViewJSON, ViewBookmarks, ViewCmdLog, ViewExplain, ViewERD:
 		// These views don't have text input
 		return true
 	case ViewBrowser:
@@ -748,6 +797,17 @@ func (m *MainModel) renderHelpOverlay() string {
 			Keys.Global.Back,
 		))
 
+	case ViewERD:
+		b.WriteString(styles.RenderKey("ER Diagram\n\n"))
+		b.WriteString(RenderBindingHelp(
+			Keys.ERD.NextTable,
+			Keys.ERD.PrevTable,
+			Keys.ERD.ToggleZoom,
+			Keys.ERD.ScrollUp,
+			Keys.ERD.ScrollDown,
+			Keys.Global.Back,
+		))
+
 	default:
 		b.WriteString("No help available for this view\n")
 	}
@@ -864,6 +924,7 @@ func (m *MainModel) renderGlobalHelpBar() string {
 		Keys.Browser.History,
 		Keys.Browser.AIChat,
 		Keys.Global.CmdLog,
+		Keys.Global.ERDiagram,
 		Keys.Global.Import,
 		Keys.Global.ReadOnly,
 		Keys.Global.CycleLayout,

--- a/cli/internal/tui/pane_impl.go
+++ b/cli/internal/tui/pane_impl.go
@@ -38,6 +38,8 @@ var (
 	_ Pane = (*BookmarksView)(nil)
 	_ Pane = (*JSONViewer)(nil)
 	_ Pane = (*CmdLogView)(nil)
+	_ Pane = (*ExplainView)(nil)
+	_ Pane = (*ERDView)(nil)
 )
 
 // ---------------------------------------------------------------------------
@@ -100,6 +102,7 @@ func (v *EditorView) SetCompact(c bool) { v.compact = c }
 func (v *EditorView) HelpBindings() []key.Binding {
 	bindings := []key.Binding{
 		key.NewBinding(key.WithKeys(styles.KeyExecute), key.WithHelp(styles.KeyExecute, styles.KeyExecuteDesc)),
+		Keys.Editor.Explain,
 		Keys.Editor.Format,
 		Keys.Editor.OpenEditor,
 		Keys.Editor.Bookmarks,
@@ -249,3 +252,40 @@ func (v *CmdLogView) OnFocus()                        {}
 func (v *CmdLogView) OnBlur()                         {}
 func (v *CmdLogView) SetCompact(bool)                 {}
 func (v *CmdLogView) HelpBindings() []key.Binding     { return nil }
+
+// ---------------------------------------------------------------------------
+// ExplainView
+// ---------------------------------------------------------------------------
+
+func (v *ExplainView) UpdatePane(msg tea.Msg) tea.Cmd  { _, cmd := v.Update(msg); return cmd }
+func (v *ExplainView) SetDimensions(width, height int) { v.width = width; v.height = height }
+func (v *ExplainView) Focusable() bool                 { return true }
+func (v *ExplainView) OnFocus()                        {}
+func (v *ExplainView) OnBlur()                         {}
+func (v *ExplainView) SetCompact(bool)                 {}
+func (v *ExplainView) HelpBindings() []key.Binding     { return nil }
+
+// ---------------------------------------------------------------------------
+// ERDView
+// ---------------------------------------------------------------------------
+
+// UpdatePane wraps the ERDView's Update method for polymorphic dispatch.
+func (v *ERDView) UpdatePane(msg tea.Msg) tea.Cmd { _, cmd := v.Update(msg); return cmd }
+
+// SetDimensions sets the available width and height for the ERD view.
+func (v *ERDView) SetDimensions(width, height int) { v.width = width; v.height = height }
+
+// Focusable returns true because the ERD view can receive keyboard focus.
+func (v *ERDView) Focusable() bool { return true }
+
+// OnFocus is called when the ERD view gains keyboard focus.
+func (v *ERDView) OnFocus() {}
+
+// OnBlur is called when the ERD view loses keyboard focus.
+func (v *ERDView) OnBlur() {}
+
+// SetCompact is a no-op for the ERD view (it has its own zoom toggle).
+func (v *ERDView) SetCompact(bool) {}
+
+// HelpBindings returns the key bindings to display in the global help bar.
+func (v *ERDView) HelpBindings() []key.Binding { return nil }

--- a/cli/internal/tui/pane_test.go
+++ b/cli/internal/tui/pane_test.go
@@ -34,7 +34,7 @@ func TestPaneRegistryPopulated(t *testing.T) {
 		ViewConnection, ViewBrowser, ViewEditor, ViewResults,
 		ViewHistory, ViewExport, ViewWhere, ViewColumns,
 		ViewChat, ViewSchema, ViewImport, ViewBookmarks, ViewJSON,
-		ViewCmdLog,
+		ViewCmdLog, ViewExplain, ViewERD,
 	}
 
 	if len(m.panes) != len(expectedModes) {

--- a/desktop-common/Makefile.common
+++ b/desktop-common/Makefile.common
@@ -511,7 +511,7 @@ server-amd64: | $(SERVER_BUILD_DIR)
 	@cd ../core && CGO_CFLAGS="$(CGO_OPT_CFLAGS)" CGO_LDFLAGS="$(CGO_OPT_LDFLAGS)" \
 		CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -tags prod -trimpath \
 		-ldflags="-s -w -X github.com/clidey/whodb/core/src/env.ApplicationVersion=$(VERSION) -X github.com/clidey/whodb/core/src/env.ApplicationEnvironment=linux-amd64" \
-		-o ../desktop-common/$(SERVER_BUILD_DIR)/$(SERVER_BINARY_NAME)-$(VERSION)-linux-amd64 .
+		-o ../desktop-common/$(SERVER_BUILD_DIR)/$(SERVER_BINARY_NAME)-$(VERSION)-linux-amd64 ./cmd/whodb
 	@echo "✅ Built: $(SERVER_BUILD_DIR)/$(SERVER_BINARY_NAME)-$(VERSION)-linux-amd64"
 
 # Build server for arm64
@@ -520,7 +520,7 @@ server-arm64: | $(SERVER_BUILD_DIR)
 	@cd ../core && CGO_CFLAGS="$(CGO_OPT_CFLAGS)" CGO_LDFLAGS="$(CGO_OPT_LDFLAGS)" \
 		CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc go build -tags prod -trimpath \
 		-ldflags="-s -w -X github.com/clidey/whodb/core/src/env.ApplicationVersion=$(VERSION) -X github.com/clidey/whodb/core/src/env.ApplicationEnvironment=linux-arm64" \
-		-o ../desktop-common/$(SERVER_BUILD_DIR)/$(SERVER_BINARY_NAME)-$(VERSION)-linux-arm64 .
+		-o ../desktop-common/$(SERVER_BUILD_DIR)/$(SERVER_BINARY_NAME)-$(VERSION)-linux-arm64 ./cmd/whodb
 	@echo "✅ Built: $(SERVER_BUILD_DIR)/$(SERVER_BINARY_NAME)-$(VERSION)-linux-arm64"
 
 # Build server for riscv64
@@ -529,7 +529,7 @@ server-riscv64: | $(SERVER_BUILD_DIR)
 	@cd ../core && CGO_CFLAGS="$(CGO_OPT_CFLAGS)" CGO_LDFLAGS="$(CGO_OPT_LDFLAGS)" \
 		CGO_ENABLED=1 GOOS=linux GOARCH=riscv64 CC=riscv64-linux-gnu-gcc go build -tags prod -trimpath \
 		-ldflags="-s -w -X github.com/clidey/whodb/core/src/env.ApplicationVersion=$(VERSION) -X github.com/clidey/whodb/core/src/env.ApplicationEnvironment=linux-riscv64" \
-		-o ../desktop-common/$(SERVER_BUILD_DIR)/$(SERVER_BINARY_NAME)-$(VERSION)-linux-riscv64 .
+		-o ../desktop-common/$(SERVER_BUILD_DIR)/$(SERVER_BINARY_NAME)-$(VERSION)-linux-riscv64 ./cmd/whodb
 	@echo "✅ Built: $(SERVER_BUILD_DIR)/$(SERVER_BINARY_NAME)-$(VERSION)-linux-riscv64"
 
 # Build server for armv6
@@ -538,7 +538,7 @@ server-armv6: | $(SERVER_BUILD_DIR)
 	@cd ../core && CGO_CFLAGS="$(CGO_OPT_CFLAGS)" CGO_LDFLAGS="$(CGO_OPT_LDFLAGS)" \
 		CGO_ENABLED=1 GOOS=linux GOARCH=arm GOARM=6 CC=arm-linux-gnueabihf-gcc go build -tags prod -trimpath \
 		-ldflags="-s -w -X github.com/clidey/whodb/core/src/env.ApplicationVersion=$(VERSION) -X github.com/clidey/whodb/core/src/env.ApplicationEnvironment=linux-armv6" \
-		-o ../desktop-common/$(SERVER_BUILD_DIR)/$(SERVER_BINARY_NAME)-$(VERSION)-linux-armv6 .
+		-o ../desktop-common/$(SERVER_BUILD_DIR)/$(SERVER_BINARY_NAME)-$(VERSION)-linux-armv6 ./cmd/whodb
 	@echo "✅ Built: $(SERVER_BUILD_DIR)/$(SERVER_BINARY_NAME)-$(VERSION)-linux-armv6"
 
 # Build server for armv7
@@ -547,7 +547,7 @@ server-armv7: | $(SERVER_BUILD_DIR)
 	@cd ../core && CGO_CFLAGS="$(CGO_OPT_CFLAGS)" CGO_LDFLAGS="$(CGO_OPT_LDFLAGS)" \
 		CGO_ENABLED=1 GOOS=linux GOARCH=arm GOARM=7 CC=arm-linux-gnueabihf-gcc go build -tags prod -trimpath \
 		-ldflags="-s -w -X github.com/clidey/whodb/core/src/env.ApplicationVersion=$(VERSION) -X github.com/clidey/whodb/core/src/env.ApplicationEnvironment=linux-armv7" \
-		-o ../desktop-common/$(SERVER_BUILD_DIR)/$(SERVER_BINARY_NAME)-$(VERSION)-linux-armv7 .
+		-o ../desktop-common/$(SERVER_BUILD_DIR)/$(SERVER_BINARY_NAME)-$(VERSION)-linux-armv7 ./cmd/whodb
 	@echo "✅ Built: $(SERVER_BUILD_DIR)/$(SERVER_BINARY_NAME)-$(VERSION)-linux-armv7"
 
 # Build all server binaries


### PR DESCRIPTION
* Add 20+ language translations (any issues or inaccuracies please contact support@clidey.com)
* Add option to change language in the settings after login
* Changes to how loading is done for WhoDB Enterprise - the community version has been cleaned up due to this
* Upgrade DuckDB driver version
* Bug fix that caused user to log out of all profiles instead of a single one when clicking Log Out
* New option and command to import data in the CLI
* Different CLI themes
* Option to switch layouts in CLI based on terminal size
* Better shortcut layout in the CLI
* Fix for CLI not being able to connect to SQLite databases in certain situations
* CLI option to auto-format SQL
* CLI option to open script in whatever editor the user has configured in their shell
* CLI option to create multiple tabs in the SQL editor view
* CLI option to view data as JSON
* CLI read-only shortcut mode
* CLI option to detect existing docker container databases
* CLI bug fix that prevented logging in to some databases
* CLI History moved to Editor view, and new Command Log shortcut added
* CLI SSH Tunnel support
* CLI ER diagram option
* CLI Explain option