### PR TITLE
Use logout route for disconnect menu

### DIFF
--- a/frontend/src/hooks/useDesktop.ts
+++ b/frontend/src/hooks/useDesktop.ts
@@ -167,7 +167,7 @@ export const useDesktopMenu = () => {
       'menu:disconnect': safeHandler(async () => {
         const confirm = await showConfirm('Disconnect', 'Are you sure you want to disconnect from the current database?');
         if (confirm) {
-          navigate('/');
+          navigate(InternalRoutes.Logout.path);
         }
       }),
       'menu:new-scratchpad-page': safeHandler(() => {


### PR DESCRIPTION
Disconnect was just navigating home instead of actually logging out. Changed it to use the logout route.

Fixes #926