### PR TITLE
fix(frontend): await health check before scheduling the next poll

### DIFF
--- a/frontend/src/services/health-check.ts
+++ b/frontend/src/services/health-check.ts
@@ -161,15 +161,6 @@ class HealthCheckService {
         }
     }
 
-    /**
-     * Reschedules the health check with the current interval.
-     *
-     * The timer callback awaits performHealthCheck before calling reschedule
-     * again. Without the await, a slow health query would overlap with the
-     * next one, and reschedule would read currentInterval / consecutiveFailures
-     * before performHealthCheck had a chance to update them via
-     * increaseInterval / resetInterval. See issue #925.
-     */
     private reschedule(): void {
         if (this.intervalId !== null) {
             clearTimeout(this.intervalId);
@@ -180,9 +171,6 @@ class HealthCheckService {
                 try {
                     await this.performHealthCheck();
                 } finally {
-                    // performHealthCheck catches its own errors, but guard
-                    // against unexpected throws so one bad check cannot stop
-                    // the polling loop entirely.
                     this.reschedule();
                 }
             }, this.currentInterval);

--- a/frontend/src/services/health-check.ts
+++ b/frontend/src/services/health-check.ts
@@ -163,6 +163,12 @@ class HealthCheckService {
 
     /**
      * Reschedules the health check with the current interval.
+     *
+     * The timer callback awaits performHealthCheck before calling reschedule
+     * again. Without the await, a slow health query would overlap with the
+     * next one, and reschedule would read currentInterval / consecutiveFailures
+     * before performHealthCheck had a chance to update them via
+     * increaseInterval / resetInterval. See issue #925.
      */
     private reschedule(): void {
         if (this.intervalId !== null) {
@@ -170,9 +176,15 @@ class HealthCheckService {
         }
 
         if (this.isRunning) {
-            this.intervalId = setTimeout(() => {
-                this.performHealthCheck();
-                this.reschedule();
+            this.intervalId = setTimeout(async () => {
+                try {
+                    await this.performHealthCheck();
+                } finally {
+                    // performHealthCheck catches its own errors, but guard
+                    // against unexpected throws so one bad check cannot stop
+                    // the polling loop entirely.
+                    this.reschedule();
+                }
             }, this.currentInterval);
         }
     }


### PR DESCRIPTION
### Problem

`HealthCheckService.reschedule()` fires the health check without awaiting
it and schedules the next timer synchronously:

```ts
this.intervalId = setTimeout(() => {
    this.performHealthCheck();   // Promise dropped on the floor
    this.reschedule();            // scheduled before the previous one finishes
}, this.currentInterval);
```

Two failure modes flow from that, both called out in #925:

1. **Overlapping requests.** If `checkHealth()` takes longer than
   `currentInterval`, the next timer fires while the previous GraphQL
   request is still in flight. Slow backends quickly accumulate several
   in-flight health queries.
2. **Stale backoff.** `performHealthCheck` mutates `currentInterval` and
   `consecutiveFailures` via `increaseInterval`/`resetInterval` only after
   `await this.checkHealth()` resolves. Because `reschedule()` ran
   synchronously, every next timeout was scheduled with the previous
   interval, so exponential backoff always trailed one check behind the
   failure that triggered it.

### Fix

Make the timer callback async, await `performHealthCheck`, and only then
reschedule. Wrap the call in `try/finally` so one unexpected throw in
`performHealthCheck` cannot strand the polling loop.

```ts
this.intervalId = setTimeout(async () => {
    try {
        await this.performHealthCheck();
    } finally {
        this.reschedule();
    }
}, this.currentInterval);
```

With this change:

- Only one health request is ever in flight at a time.
- `currentInterval` reflects the outcome of the just-finished check, so
  the next timeout uses the correctly bumped-or-reset value.
- `stop()` still works: it nulls `intervalId` and sets `isRunning = false`
  before the `finally` block, so the trailing `reschedule()` no-ops.

Fixes #925
