### PR TITLE
fix(frontend): read auth and route through refs in desktop menu handlers

### DIFF
--- a/frontend/src/hooks/useDesktop.ts
+++ b/frontend/src/hooks/useDesktop.ts
@@ -97,11 +97,6 @@ export const useDesktopMenu = () => {
   const { showConfirm } = useDesktopDialog();
   const currentAuth = useAppSelector(state => state.auth.current);
 
-  // The menu handlers below are registered with desktopService exactly once
-  // (the useEffect depends only on isDesktop) and therefore close over stale
-  // values of auth state and the current route on every app transition. Mirror
-  // those values into refs that each render updates, so handlers always see
-  // the live values when the user actually triggers a menu action.
   const currentAuthRef = useRef(currentAuth);
   const locationRef = useRef(location);
   currentAuthRef.current = currentAuth;

--- a/frontend/src/hooks/useDesktop.ts
+++ b/frontend/src/hooks/useDesktop.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {useCallback, useEffect} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 import {useLocation, useNavigate} from 'react-router-dom';
 import * as desktopService from '../services/desktop';
 import {isDesktopApp} from '../utils/external-links';
@@ -97,6 +97,16 @@ export const useDesktopMenu = () => {
   const { showConfirm } = useDesktopDialog();
   const currentAuth = useAppSelector(state => state.auth.current);
 
+  // The menu handlers below are registered with desktopService exactly once
+  // (the useEffect depends only on isDesktop) and therefore close over stale
+  // values of auth state and the current route on every app transition. Mirror
+  // those values into refs that each render updates, so handlers always see
+  // the live values when the user actually triggers a menu action.
+  const currentAuthRef = useRef(currentAuth);
+  const locationRef = useRef(location);
+  currentAuthRef.current = currentAuth;
+  locationRef.current = location;
+
   useEffect(() => {
     if (!isDesktop) return;
 
@@ -134,7 +144,7 @@ export const useDesktopMenu = () => {
 
     const handlers = {
       'menu:toggle-sidebar-new-connection': safeHandler(() => {
-        if (currentAuth) {
+        if (currentAuthRef.current) {
           // User is logged in - emit event to open sidebar with add profile form
           window.dispatchEvent(new CustomEvent('menu:open-add-profile'));
         } else {
@@ -172,7 +182,7 @@ export const useDesktopMenu = () => {
       }),
       'menu:new-scratchpad-page': safeHandler(() => {
         // Only allow creating new page if already on Scratchpad page
-        if (location.pathname === InternalRoutes.RawExecute.path) {
+        if (locationRef.current.pathname === InternalRoutes.RawExecute.path) {
           // Emit event that the Scratchpad page will listen to
           window.dispatchEvent(new CustomEvent('menu:new-scratchpad-page'));
         }


### PR DESCRIPTION
## What

`useDesktopMenu` in `frontend/src/hooks/useDesktop.ts` registers its menu-event handlers with `desktopService` inside a `useEffect` whose dependency array is only `[isDesktop]`. The handlers themselves close over `currentAuth` (redux selector) and `location.pathname` (react-router). Since the effect only runs once, after the initial mount the registered closures always see the mount-time values.

Observable effects from #927:

- **File → New Connection** still takes the unauthenticated branch (`navigate("/login")`) after the user has logged in, because `currentAuth` inside the closure stays stuck at the initial `undefined`.
- **Database → New Scratchpad Page** checks `location.pathname === InternalRoutes.RawExecute.path` against the mount-time path, so navigating to Scratchpad and then firing the shortcut can still no-op when the captured path was something else.

## Fix

Re-registering handlers on every auth/route change would create races with in-flight `desktopService` dispatch plus churn on `offEvent`/`onEvent` calls. Instead, mirror the two moving values into refs that every render refreshes, and have the handlers read `currentAuthRef.current` and `locationRef.current.pathname` at invocation time:

```tsx
const currentAuthRef = useRef(currentAuth);
const locationRef = useRef(location);
currentAuthRef.current = currentAuth;
locationRef.current = location;

useEffect(() => {
    if (!isDesktop) return;
    ...
    'menu:toggle-sidebar-new-connection': safeHandler(() => {
        if (currentAuthRef.current) { ... }
    }),
    'menu:new-scratchpad-page': safeHandler(() => {
        if (locationRef.current.pathname === InternalRoutes.RawExecute.path) { ... }
    }),
    ...
}, [isDesktop]);
```

The effect stays keyed on `[isDesktop]` (registering handlers is a one-time setup), and the handlers now observe the live values. `navigate` and `showConfirm` are already stable across renders from react-router / the dialog hook, so they don't need the same treatment.

## Not changed

- `File → New Connection` path and `menu:new-scratchpad-page` gate logic is untouched; only the source of the values they read.
- `menu:disconnect` already uses the shared `showConfirm` and then `navigate("/")`; routing it through `/logout` is a separate issue/PR (#926 → #928).

Fixes #927