### PR TITLE
feat: normalize storage size reporting across plugins (#932)

### DIFF
--- a/core/src/plugins/clickhouse/clickhouse.go
+++ b/core/src/plugins/clickhouse/clickhouse.go
@@ -142,7 +142,7 @@ func (p *ClickHousePlugin) GetTableInfoQuery() string {
 			name,
 			engine,
 			total_rows,
-			formatReadableSize(total_bytes) as total_size
+			total_bytes
 		FROM system.tables
 		WHERE database = ?
 		AND name NOT LIKE '.inner%'
@@ -155,29 +155,24 @@ func (p *ClickHousePlugin) GetStorageUnitExistsQuery() string {
 
 func (p *ClickHousePlugin) GetTableNameAndAttributes(rows *sql.Rows) (string, []engine.Record) {
 	var tableName, tableType string
-	var totalRows *uint64
-	var totalSize *string
+	var totalRows, totalBytes *uint64
 
-	if err := rows.Scan(&tableName, &tableType, &totalRows, &totalSize); err != nil {
+	if err := rows.Scan(&tableName, &tableType, &totalRows, &totalBytes); err != nil {
 		log.WithError(err).Error("Failed to scan table name and attributes from ClickHouse system.tables query")
 		return "", nil
 	}
 
+	attributes := []engine.Record{
+		{Key: "Type", Value: tableType},
+	}
+	if totalBytes != nil {
+		attributes = append(attributes, engine.Record{Key: "Total Size", Value: strconv.FormatUint(*totalBytes, 10)})
+	}
 	rowCount := "0"
 	if totalRows != nil {
 		rowCount = strconv.FormatUint(*totalRows, 10)
 	}
-
-	size := "unknown"
-	if totalSize != nil {
-		size = *totalSize
-	}
-
-	attributes := []engine.Record{
-		{Key: "Type", Value: tableType},
-		{Key: "Total Size", Value: size},
-		{Key: "Count", Value: rowCount},
-	}
+	attributes = append(attributes, engine.Record{Key: "Count", Value: rowCount})
 
 	return tableName, attributes
 }

--- a/core/src/plugins/elasticsearch/elasticsearch.go
+++ b/core/src/plugins/elasticsearch/elasticsearch.go
@@ -106,10 +106,12 @@ func (p *ElasticSearchPlugin) GetStorageUnits(config *engine.PluginConfig, datab
 	}
 	defer res.Body.Close()
 
+	// _stats requires the monitor cluster privilege. If it is denied (403) or
+	// otherwise errors, fall back to listing indices without size/count so the
+	// UI remains usable for read-only callers.
 	if res.IsError() {
-		err := fmt.Errorf("error getting stats for indices: %s", res.String())
-		log.WithError(err).Error("ElasticSearch indices stats API returned error")
-		return nil, err
+		log.Warnf("ElasticSearch indices stats API returned error (%d); falling back to index-only listing", res.StatusCode)
+		return p.listIndicesWithoutStats(config)
 	}
 
 	var stats map[string]any
@@ -132,42 +134,65 @@ func (p *ElasticSearchPlugin) GetStorageUnits(config *engine.PluginConfig, datab
 			continue
 		}
 
+		attrs := []engine.Record{{Key: "Type", Value: "Index"}}
+
 		indexStats, ok := indexStatsInterface.(map[string]any)
 		if !ok {
-			log.Warnf("Skipping index %s: unexpected stats format", indexName)
+			log.Warnf("Skipping stats for index %s: unexpected format", indexName)
+			storageUnits = append(storageUnits, engine.StorageUnit{Name: indexName, Attributes: attrs})
 			continue
 		}
 
-		primaries, ok := indexStats["primaries"].(map[string]any)
-		if !ok {
-			log.Warnf("Skipping index %s: missing primaries data", indexName)
-			continue
+		primaries, _ := indexStats["primaries"].(map[string]any)
+		if store, ok := primaries["store"].(map[string]any); ok {
+			if bytes, ok := toInt64(store["size_in_bytes"]); ok {
+				attrs = append(attrs, engine.Record{Key: "Data Size", Value: fmt.Sprintf("%d", bytes)})
+			}
+		}
+		if docs, ok := primaries["docs"].(map[string]any); ok {
+			if count, ok := toInt64(docs["count"]); ok {
+				attrs = append(attrs, engine.Record{Key: "Count", Value: fmt.Sprintf("%d", count)})
+			}
 		}
 
-		docs, ok := primaries["docs"].(map[string]any)
-		if !ok {
-			log.Warnf("Skipping index %s: missing docs data", indexName)
-			continue
-		}
-
-		store, ok := primaries["store"].(map[string]any)
-		if !ok {
-			log.Warnf("Skipping index %s: missing store data", indexName)
-			continue
-		}
-
-		storageUnit := engine.StorageUnit{
-			Name: indexName,
-			Attributes: []engine.Record{
-				{Key: "Type", Value: "Index"},
-				{Key: "Storage Size", Value: fmt.Sprintf("%v", store["size_in_bytes"])},
-				{Key: "Count", Value: fmt.Sprintf("%v", docs["count"])},
-			},
-		}
-		storageUnits = append(storageUnits, storageUnit)
+		storageUnits = append(storageUnits, engine.StorageUnit{Name: indexName, Attributes: attrs})
 	}
 
 	return storageUnits, nil
+}
+
+// listIndicesWithoutStats returns indices visible to the caller but without
+// size/count attributes. Used when _stats is unavailable (e.g., 403 Forbidden).
+func (p *ElasticSearchPlugin) listIndicesWithoutStats(config *engine.PluginConfig) ([]engine.StorageUnit, error) {
+	names, err := p.GetDatabases(config)
+	if err != nil {
+		return nil, err
+	}
+	units := make([]engine.StorageUnit, 0, len(names))
+	for _, name := range names {
+		units = append(units, engine.StorageUnit{
+			Name:       name,
+			Attributes: []engine.Record{{Key: "Type", Value: "Index"}},
+		})
+	}
+	return units, nil
+}
+
+// toInt64 extracts an int64 from a JSON-decoded value, handling the common
+// numeric forms encoutered when encoding/json targets an any.
+func toInt64(v any) (int64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return int64(n), true
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	case json.Number:
+		i, err := n.Int64()
+		return i, err == nil
+	}
+	return 0, false
 }
 
 func (p *ElasticSearchPlugin) StorageUnitExists(config *engine.PluginConfig, database string, index string) (bool, error) {

--- a/core/src/plugins/memcached/memcached.go
+++ b/core/src/plugins/memcached/memcached.go
@@ -77,7 +77,7 @@ func (p *MemcachedPlugin) GetStorageUnits(config *engine.PluginConfig, schema st
 			Name: entry.Key,
 			Attributes: []engine.Record{
 				{Key: "Type", Value: "string"},
-				{Key: "Size", Value: strconv.Itoa(entry.Size)},
+				{Key: "Data Size", Value: strconv.Itoa(entry.Size)},
 				{Key: "Expires", Value: expValue},
 			},
 		})

--- a/core/src/plugins/mongodb/mongodb.go
+++ b/core/src/plugins/mongodb/mongodb.go
@@ -132,21 +132,35 @@ func (p *MongoDBPlugin) GetStorageUnits(config *engine.PluginConfig, database st
 				{Key: "View On", Value: viewOn},
 			}
 		} else {
+			attrs := []engine.Record{{Key: "Type", Value: "Collection"}}
+
+			// collStats requires read privilege on the collection. If denied
+			// (or the server rejects for any reason), keep the collection
+			// visible and omit size/count rather than aborting the listing.
 			stats := bson.M{}
-			err := db.RunCommand(ctx, bson.D{{Key: "collStats", Value: collectionName}}).Decode(&stats)
-			if err != nil {
+			if err := db.RunCommand(ctx, bson.D{{Key: "collStats", Value: collectionName}}).Decode(&stats); err != nil {
 				log.WithError(err).WithFields(map[string]any{
 					"hostname":   config.Credentials.Hostname,
 					"database":   database,
 					"collection": collectionName,
-				}).Error("Failed to get MongoDB collection statistics")
-				return nil, err
-			}
-
-			storageUnit.Attributes = []engine.Record{
-				{Key: "Type", Value: "Collection"},
-				{Key: "Storage Size", Value: fmt.Sprintf("%v", stats["storageSize"])},
-				{Key: "Count", Value: fmt.Sprintf("%v", stats["count"])},
+				}).Warn("collStats unavailable for MongoDB collection; omitting size/count")
+				storageUnit.Attributes = attrs
+			} else {
+				storageSize, hasStorage := toInt64(stats["storageSize"])
+				if hasStorage {
+					attrs = append(attrs, engine.Record{Key: "Data Size", Value: fmt.Sprintf("%d", storageSize)})
+				}
+				if totalSize, ok := toInt64(stats["totalSize"]); ok {
+					attrs = append(attrs, engine.Record{Key: "Total Size", Value: fmt.Sprintf("%d", totalSize)})
+				} else if hasStorage {
+					if indexSize, ok := toInt64(stats["totalIndexSize"]); ok {
+						attrs = append(attrs, engine.Record{Key: "Total Size", Value: fmt.Sprintf("%d", storageSize+indexSize)})
+					}
+				}
+				if count, ok := toInt64(stats["count"]); ok {
+					attrs = append(attrs, engine.Record{Key: "Count", Value: fmt.Sprintf("%d", count)})
+				}
+				storageUnit.Attributes = attrs
 			}
 		}
 
@@ -332,6 +346,23 @@ func parseMongoDBJsonSchema(schema map[string]any) map[string]map[string]any {
 	}
 
 	return constraints
+}
+
+// toInt64 converts common BSON numeric types to int64.
+func toInt64(v any) (int64, bool) {
+	switch val := v.(type) {
+	case int64:
+		return val, true
+	case int32:
+		return int64(val), true
+	case int:
+		return int64(val), true
+	case float64:
+		return int64(val), true
+	case float32:
+		return int64(val), true
+	}
+	return 0, false
 }
 
 // toFloat64 converts common BSON numeric types to float64.

--- a/core/src/plugins/mysql/mysql.go
+++ b/core/src/plugins/mysql/mysql.go
@@ -105,8 +105,8 @@ func (p *MySQLPlugin) GetTableInfoQuery() string {
 		SELECT
 			TABLE_NAME,
 			TABLE_TYPE,
-			IFNULL(ROUND(((DATA_LENGTH + INDEX_LENGTH) / 1024 / 1024), 2), 0) AS total_size,
-			IFNULL(ROUND((DATA_LENGTH / 1024 / 1024), 2), 0) AS data_size
+			(DATA_LENGTH + INDEX_LENGTH) AS total_size,
+			DATA_LENGTH AS data_size
 		FROM
 			INFORMATION_SCHEMA.TABLES
 		WHERE
@@ -123,7 +123,7 @@ func (p *MySQLPlugin) GetPlaceholder(index int) string {
 
 func (p *MySQLPlugin) GetTableNameAndAttributes(rows *sql.Rows) (string, []engine.Record) {
 	var tableName, tableType string
-	var totalSize, dataSize float64
+	var totalSize, dataSize sql.NullInt64
 	if err := rows.Scan(&tableName, &tableType, &totalSize, &dataSize); err != nil {
 		log.WithError(err).Error("Failed to scan MySQL table information")
 		return "", []engine.Record{}
@@ -131,8 +131,12 @@ func (p *MySQLPlugin) GetTableNameAndAttributes(rows *sql.Rows) (string, []engin
 
 	attributes := []engine.Record{
 		{Key: "Type", Value: tableType},
-		{Key: "Total Size", Value: fmt.Sprintf("%.2f MB", totalSize)},
-		{Key: "Data Size", Value: fmt.Sprintf("%.2f MB", dataSize)},
+	}
+	if totalSize.Valid {
+		attributes = append(attributes, engine.Record{Key: "Total Size", Value: fmt.Sprintf("%d", totalSize.Int64)})
+	}
+	if dataSize.Valid {
+		attributes = append(attributes, engine.Record{Key: "Data Size", Value: fmt.Sprintf("%d", dataSize.Int64)})
 	}
 	return tableName, attributes
 }

--- a/core/src/plugins/postgres/postgres.go
+++ b/core/src/plugins/postgres/postgres.go
@@ -59,19 +59,26 @@ func (p *PostgresPlugin) GetAllSchemasQuery() string {
 }
 
 func (p *PostgresPlugin) GetTableInfoQuery() string {
+	// Guard pg_*_relation_size with has_table_privilege so a single restricted
+	// relation does not error the whole listing. NULL sizes propagate up and
+	// are emitted as absent attributes rather than "0".
 	return `
 		SELECT
 			t.table_name,
 			t.table_type,
-			pg_size_pretty(pg_total_relation_size(quote_ident(t.table_schema) || '.' || quote_ident(t.table_name))) AS total_size,
-			pg_size_pretty(pg_relation_size(quote_ident(t.table_schema) || '.' || quote_ident(t.table_name))) AS data_size
+			CASE WHEN c.oid IS NOT NULL AND has_table_privilege(c.oid, 'SELECT')
+				THEN pg_total_relation_size(c.oid)::bigint
+				ELSE NULL END AS total_size,
+			CASE WHEN c.oid IS NOT NULL AND has_table_privilege(c.oid, 'SELECT')
+				THEN pg_relation_size(c.oid)::bigint
+				ELSE NULL END AS data_size
 		FROM
 			information_schema.tables t
+		LEFT JOIN pg_namespace n ON n.nspname = t.table_schema
+		LEFT JOIN pg_class c ON c.relname = t.table_name AND c.relnamespace = n.oid
 		WHERE
 			t.table_schema = ?;
 	`
-
-	// AND t.table_type = 'BASE TABLE' this removes the view tables
 }
 
 func (p *PostgresPlugin) GetStorageUnitExistsQuery() string {
@@ -83,7 +90,8 @@ func (p *PostgresPlugin) GetPlaceholder(index int) string {
 }
 
 func (p *PostgresPlugin) GetTableNameAndAttributes(rows *sql.Rows) (string, []engine.Record) {
-	var tableName, tableType, totalSize, dataSize string
+	var tableName, tableType string
+	var totalSize, dataSize sql.NullInt64
 	if err := rows.Scan(&tableName, &tableType, &totalSize, &dataSize); err != nil {
 		log.WithError(err).Error("Failed to scan table info row data")
 		return "", nil
@@ -91,8 +99,12 @@ func (p *PostgresPlugin) GetTableNameAndAttributes(rows *sql.Rows) (string, []en
 
 	attributes := []engine.Record{
 		{Key: "Type", Value: tableType},
-		{Key: "Total Size", Value: totalSize},
-		{Key: "Data Size", Value: dataSize},
+	}
+	if totalSize.Valid {
+		attributes = append(attributes, engine.Record{Key: "Total Size", Value: fmt.Sprintf("%d", totalSize.Int64)})
+	}
+	if dataSize.Valid {
+		attributes = append(attributes, engine.Record{Key: "Data Size", Value: fmt.Sprintf("%d", dataSize.Int64)})
 	}
 
 	return tableName, attributes

--- a/core/src/plugins/redis/redis.go
+++ b/core/src/plugins/redis/redis.go
@@ -130,9 +130,11 @@ func (p *RedisPlugin) GetStorageUnits(config *engine.PluginConfig, schema string
 				log.WithError(err).WithField("key", key).Error("Failed to get string key size")
 				return nil, err
 			}
+			// StrLen returns bytes — maps to Data Size, so the UI renders
+			// auto-scaled units (KB/MB/...) like other byte-valued attributes.
 			attributes = []engine.Record{
 				{Key: "Type", Value: "string"},
-				{Key: "Size", Value: fmt.Sprintf("%d", size)},
+				{Key: "Data Size", Value: fmt.Sprintf("%d", size)},
 			}
 		case "hash":
 			sizeCmd := pipe.HLen(ctx, key)
@@ -147,7 +149,7 @@ func (p *RedisPlugin) GetStorageUnits(config *engine.PluginConfig, schema string
 			}
 			attributes = []engine.Record{
 				{Key: "Type", Value: "hash"},
-				{Key: "Size", Value: fmt.Sprintf("%d", size)},
+				{Key: "Entries", Value: fmt.Sprintf("%d", size)},
 			}
 		case "list":
 			sizeCmd := pipe.LLen(ctx, key)
@@ -162,7 +164,7 @@ func (p *RedisPlugin) GetStorageUnits(config *engine.PluginConfig, schema string
 			}
 			attributes = []engine.Record{
 				{Key: "Type", Value: "list"},
-				{Key: "Size", Value: fmt.Sprintf("%d", size)},
+				{Key: "Entries", Value: fmt.Sprintf("%d", size)},
 			}
 		case "set":
 			sizeCmd := pipe.SCard(ctx, key)
@@ -177,7 +179,7 @@ func (p *RedisPlugin) GetStorageUnits(config *engine.PluginConfig, schema string
 			}
 			attributes = []engine.Record{
 				{Key: "Type", Value: "set"},
-				{Key: "Size", Value: fmt.Sprintf("%d", size)},
+				{Key: "Entries", Value: fmt.Sprintf("%d", size)},
 			}
 		case "zset":
 			sizeCmd := pipe.ZCard(ctx, key)
@@ -192,7 +194,7 @@ func (p *RedisPlugin) GetStorageUnits(config *engine.PluginConfig, schema string
 			}
 			attributes = []engine.Record{
 				{Key: "Type", Value: "zset"},
-				{Key: "Size", Value: fmt.Sprintf("%d", size)},
+				{Key: "Entries", Value: fmt.Sprintf("%d", size)},
 			}
 		default:
 			attributes = []engine.Record{

--- a/frontend/e2e/support/categories/document.mjs
+++ b/frontend/e2e/support/categories/document.mjs
@@ -110,7 +110,7 @@ export function verifyMetadata(fields, metadata) {
         expect(typeField[1]).toEqual(metadata.type);
     }
     if (metadata.hasStorageSize) {
-        expect(fields.some(([k]) => k === 'Storage Size')).toBeTruthy();
+        expect(fields.some(([k]) => k === 'Data Size')).toBeTruthy();
     }
     if (metadata.hasCount) {
         expect(fields.some(([k]) => k === 'Count')).toBeTruthy();

--- a/frontend/e2e/support/categories/keyvalue.mjs
+++ b/frontend/e2e/support/categories/keyvalue.mjs
@@ -102,7 +102,9 @@ export function verifyStringValue(rows, expectedValue) {
 export function verifyKeyMetadata(fields, expectedType) {
     const typeField = fields.find(([k, v]) => k === 'Type' && v === expectedType);
     expect(typeField, `Key should be of type: ${expectedType}`).toBeDefined();
-    expect(fields.some(([k]) => k === 'Size')).toBeTruthy();
+    // Strings expose bytes as Data Size; hash/list/set/zset expose element
+    // count as Entries. Either satisfies the "has size metadata" assertion.
+    expect(fields.some(([k]) => k === 'Data Size' || k === 'Entries')).toBeTruthy();
 }
 
 /**

--- a/frontend/e2e/tests/features/graph.spec.mjs
+++ b/frontend/e2e/tests/features/graph.spec.mjs
@@ -59,7 +59,7 @@ test.describe('Graph Visualization', () => {
                 }
                 if (tableConfig.metadata.hasSize) {
                     // Different databases use different size field names
-                    const sizeFields = ['Total Size', 'Data Size', 'Size', 'Table Size', 'Segment Size'];
+                    const sizeFields = ['Total Size', 'Data Size', 'Size', 'Table Size', 'Segment Size', 'Entries'];
                     expect(fields.some(([k]) => sizeFields.some(sf => k.includes(sf) || k.toLowerCase().includes('size'))),
                         'Should have size info').toBe(true);
                 }

--- a/frontend/src/pages/storage-unit/explore-storage-unit.tsx
+++ b/frontend/src/pages/storage-unit/explore-storage-unit.tsx
@@ -96,6 +96,7 @@ import {useContainerWidth} from "../../hooks/use-container-width";
 import {getComponent} from "../../config/component-registry";
 import { findSourceObjectType } from "../../config/source-types";
 import {buildSourceObjectRef, buildSourceParentObjectRef} from "../../utils/source-refs";
+import {formatAttributeValue} from "../../utils/functions";
 
 type SourceBrowserObject = GetStorageUnitsQuery['StorageUnit'][number];
 
@@ -860,13 +861,16 @@ export const ExploreStorageUnit: FC = () => {
                         )}
                     </div>
                     <StackList>
-                        {unit.Attributes.map(attribute => (
-                            <div key={attribute.Key} data-field-key={attribute.Key} data-field-value={attribute.Value?.toLowerCase()}>
-                                <StackListItem item={attribute.Key}>
-                                    {attribute.Value?.toLowerCase()}
-                                </StackListItem>
-                            </div>
-                        ))}
+                        {unit.Attributes.map(attribute => {
+                            const display = formatAttributeValue(attribute.Key, attribute.Value);
+                            return (
+                                <div key={attribute.Key} data-field-key={attribute.Key} data-field-value={display}>
+                                    <StackListItem item={attribute.Key}>
+                                        {display}
+                                    </StackListItem>
+                                </div>
+                            );
+                        })}
                     </StackList>
                     {sourceContentLoading ? (
                         <div className="flex justify-center items-center grow">

--- a/frontend/src/pages/storage-unit/storage-unit.tsx
+++ b/frontend/src/pages/storage-unit/storage-unit.tsx
@@ -82,6 +82,7 @@ import {Tip} from '../../components/tip';
 import {SettingsActions} from '../../store/settings';
 import {useTranslation} from '../../hooks/use-translation';
 import {buildSourceParentObjectRef, buildSourceParentRef} from '../../utils/source-refs';
+import {formatAttributeValue} from '../../utils/functions';
 import { findSourceObjectType, type SourceTypeItem } from '../../config/source-types';
 
 type SourceBrowserObject = GetStorageUnitsQuery['StorageUnit'][number];
@@ -192,7 +193,7 @@ const StorageUnitCard: FC<{
                 </Tip>
                 {
                     introAttributes.slice(0,2).map(attribute => (
-                        <p key={attribute.Key} className="text-xs">{attribute.Key}: {attribute.Value?.toLowerCase()}</p>
+                        <p key={attribute.Key} className="text-xs">{attribute.Key}: {formatAttributeValue(attribute.Key, attribute.Value)}</p>
                     ))
                 }
             </div>
@@ -223,22 +224,28 @@ const StorageUnitCard: FC<{
                     <StackList>
                         {/* Metadata attributes (Type, Total Size, etc.) */}
                         {
-                            introAttributes.map(attribute => (
-                                <div key={attribute.Key} data-field-key={attribute.Key} data-field-value={attribute.Value?.toLowerCase()}>
-                                    <StackListItem item={attribute.Key}>
-                                        {attribute.Value?.toLowerCase()}
-                                    </StackListItem>
-                                </div>
-                            ))
+                            introAttributes.map(attribute => {
+                                const display = formatAttributeValue(attribute.Key, attribute.Value);
+                                return (
+                                    <div key={attribute.Key} data-field-key={attribute.Key} data-field-value={display}>
+                                        <StackListItem item={attribute.Key}>
+                                            {display}
+                                        </StackListItem>
+                                    </div>
+                                );
+                            })
                         }
                         {
-                            expandedAttributes.map(attribute => (
-                                <div key={attribute.Key} data-field-key={attribute.Key} data-field-value={attribute.Value?.toLowerCase()}>
-                                    <StackListItem item={attribute.Key}>
-                                        {attribute.Value?.toLowerCase()}
-                                    </StackListItem>
-                                </div>
-                            ))
+                            expandedAttributes.map(attribute => {
+                                const display = formatAttributeValue(attribute.Key, attribute.Value);
+                                return (
+                                    <div key={attribute.Key} data-field-key={attribute.Key} data-field-value={display}>
+                                        <StackListItem item={attribute.Key}>
+                                            {display}
+                                        </StackListItem>
+                                    </div>
+                                );
+                            })
                         }
                     </StackList>
                     {columnsLoading && shouldFetchColumns && (
@@ -685,7 +692,7 @@ export const StorageUnitPage: FC = () => {
                             <TableRow key={unit.Name} className="group">
                                 <TableCell>{unit.Name}</TableCell>
                                 {sharedAttributeKeys.map(key => (
-                                    <TableCell key={key}>{attrMap[key] ?? ""}</TableCell>
+                                    <TableCell key={key}>{formatAttributeValue(key, attrMap[key])}</TableCell>
                                 ))}
                                 <TableCell className="relative">
                                     <div className="flex gap-xs opacity-0 group-hover:opacity-100 transition-opacity">
@@ -720,20 +727,26 @@ export const StorageUnitPage: FC = () => {
                                     <h2 className="text-2xl font-bold">{unit.Name}</h2>
                                     <StackList>
                                         {/* Metadata attributes */}
-                                        {introAttributes.map(attribute => (
-                                            <div key={attribute.Key} data-field-key={attribute.Key} data-field-value={attribute.Value?.toLowerCase()}>
-                                                <StackListItem item={attribute.Key}>
-                                                    {attribute.Value?.toLowerCase()}
-                                                </StackListItem>
-                                            </div>
-                                        ))}
-                                        {expandedAttributes.map(attribute => (
-                                            <div key={attribute.Key} data-field-key={attribute.Key} data-field-value={attribute.Value?.toLowerCase()}>
-                                                <StackListItem item={attribute.Key}>
-                                                    {attribute.Value?.toLowerCase()}
-                                                </StackListItem>
-                                            </div>
-                                        ))}
+                                        {introAttributes.map(attribute => {
+                                            const display = formatAttributeValue(attribute.Key, attribute.Value);
+                                            return (
+                                                <div key={attribute.Key} data-field-key={attribute.Key} data-field-value={display}>
+                                                    <StackListItem item={attribute.Key}>
+                                                        {display}
+                                                    </StackListItem>
+                                                </div>
+                                            );
+                                        })}
+                                        {expandedAttributes.map(attribute => {
+                                            const display = formatAttributeValue(attribute.Key, attribute.Value);
+                                            return (
+                                                <div key={attribute.Key} data-field-key={attribute.Key} data-field-value={display}>
+                                                    <StackListItem item={attribute.Key}>
+                                                        {display}
+                                                    </StackListItem>
+                                                </div>
+                                            );
+                                        })}
                                     </StackList>
                                     {expandedUnitColumnsLoading && <Loading hideText={true} />}
                                     {!expandedUnitColumnsLoading && columns && columns.length > 0 && (

--- a/frontend/src/utils/functions.ts
+++ b/frontend/src/utils/functions.ts
@@ -47,3 +47,55 @@ export function chooseRandomItems<T>(array: T[], n: number = 3): T[] {
     }
     return sampleSize(array, n);
 }
+
+/**
+ * Storage unit attribute keys whose Value is a raw byte count and should be
+ * auto-scaled for display. Plugins emit bytes as a numeric string; the
+ * frontend owns presentation.
+ */
+const BYTE_SIZE_KEYS: ReadonlySet<string> = new Set(["Total Size", "Data Size"]);
+
+/**
+ * Formats a byte count as a human-readable string, auto-scaling to B/KB/MB/GB/TB/PB.
+ * Uses 1024-based (binary) steps with decimal-suffix labels, which matches the
+ * convention users see in most file managers.
+ * @param bytes - The byte count to format. Non-finite or negative values are returned as-is.
+ */
+export function formatBytes(bytes: number): string {
+    if (!Number.isFinite(bytes) || bytes < 0) {
+        return String(bytes);
+    }
+    if (bytes < 1024) {
+        return `${bytes} B`;
+    }
+    const units = ["KB", "MB", "GB", "TB", "PB"] as const;
+    let value = bytes / 1024;
+    let unitIndex = 0;
+    while (value >= 1024 && unitIndex < units.length - 1) {
+        value /= 1024;
+        unitIndex++;
+    }
+    const precision = value < 10 ? 2 : value < 100 ? 1 : 0;
+    return `${value.toFixed(precision)} ${units[unitIndex]}`;
+}
+
+/**
+ * Formats a storage-unit attribute value for display. Size-keyed attributes
+ * (emitted as raw bytes by the backend) are auto-scaled via formatBytes();
+ * all other attributes are lowercased to match existing display conventions.
+ * Falls through to the raw value if size parsing fails, keeping pre-migration
+ * backends forward-compatible.
+ */
+export function formatAttributeValue(key: string, value: string | null | undefined): string {
+    if (value == null) {
+        return "";
+    }
+    if (BYTE_SIZE_KEYS.has(key)) {
+        const parsed = Number(value);
+        if (Number.isFinite(parsed) && parsed >= 0) {
+            return formatBytes(parsed);
+        }
+        return value;
+    }
+    return value.toLowerCase();
+}


### PR DESCRIPTION
Closes #932.

Every plugin picks its own units today — MySQL does `"%.2f MB"`, Postgres leans on `pg_size_pretty`, ClickHouse uses `formatReadableSize`, ES/Mongo call it `Storage Size`, and Redis conflates bytes and element counts under a single `Size`. So the same column renders differently depending on which tab you're on.

This PR pushes formatting out of the backend. Plugins now emit raw bytes as numeric strings under `Total Size` / `Data Size`, and a single `formatBytes()` helper auto-scales to B/KB/MB/GB/TB/PB at render time.

**Key changes**
- Drop per-plugin formatting: MySQL `"%.2f MB"`, Postgres `pg_size_pretty`, ClickHouse `formatReadableSize` are gone.
- Rename ES/Mongo `Storage Size` → `Data Size`.
- Redis `Size` → `Entries` for hash/list/set/zset (it's a count, not bytes). The `string` type keeps bytes under `Data Size` so the auto-scaler picks it up.
- Mongo now surfaces both `Data Size` (`storageSize`) and `Total Size` (`totalSize`, with `storageSize + totalIndexSize` fallback for older servers).
- Frontend: `formatBytes()` + `formatAttributeValue()` in `frontend/src/utils/functions.ts`, wired into `storage-unit.tsx` and `explore-storage-unit.tsx`.

**Permission handling** (per your heads-up in the issue)
- Postgres: `pg_*_relation_size` wrapped in `has_table_privilege(c.oid, 'SELECT')` so a restricted row returns `NULL` instead of breaking the whole query.
- MySQL/Postgres: `sql.NullInt64` — attribute is simply omitted when `NULL`.
- Elasticsearch: on a 403 from `_stats` (missing `monitor` privilege), fall back to a name-only index listing so the UI stays usable.
- Mongo: `collStats` denial logs a warning and keeps the collection visible without size/count.