### PR TITLE
fix(cli): correct update notice version comparison and formatting

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -92,7 +92,11 @@ Press ? in any view for keyboard shortcuts.`,
 			return
 		}
 		if result := updatecheck.Check(version.Version); result != nil {
-			fmt.Fprintf(os.Stderr, "\nA new version of %s is available: %s → %s\n", identity.Current().CommandName, result.LatestVersion, identity.Current().UpdateCheckPageURL)
+			fmt.Fprintf(os.Stderr, "\nA new version of %s is available: %s → %s\nUpgrade URL: %s\n",
+				identity.Current().CommandName,
+				version.Version,
+				result.LatestVersion,
+				identity.Current().UpdateCheckPageURL)
 		}
 	},
 }


### PR DESCRIPTION
## Related Issue

Closes #956

## What does this PR do?

Corrects the update notice formatting in the CLI so that both the current and latest versions are displayed, and the upgrade URL is placed on a separate line according to the issue's acceptance criteria.

## Why?

The previous implementation missed the `version.Version` argument in the `fmt.Fprintf` call, causing the output to display the latest version and URL in the wrong placeholders.

## How it works

Updated the `fmt.Fprintf` string and arguments in `cli/cmd/root.go` to properly map `version.Version`, `result.LatestVersion`, and `UpdateCheckPageURL`.

## How was this tested?

- Ran `go vet ./cmd/...` to verify formatting verbs match the provided arguments.
- Verified local build.

## Screenshots / recordings

N/A (CLI text output fix)

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I discussed this change in an issue before starting work
- [x] My PR description is written in my own words and accurately describes my changes
- [x] I have tested my changes locally
- [x] I have not included build artifacts or unrelated changes