### PR TITLE
fix(cli): skip update check for non-interactive and machine-readable …

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"github.com/clidey/whodb/cli/internal/tui"
 	"github.com/clidey/whodb/cli/pkg/analytics"
 	"github.com/clidey/whodb/cli/pkg/identity"
+	"github.com/clidey/whodb/cli/pkg/output"
 	"github.com/clidey/whodb/cli/pkg/styles"
 	"github.com/clidey/whodb/cli/pkg/updatecheck"
 	"github.com/clidey/whodb/cli/pkg/version"
@@ -88,7 +89,10 @@ Press ? in any view for keyboard shortcuts.`,
 		return nil
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		if shouldSkipStartupSideEffects() || viper.GetBool("no-update-check") || version.Version == "dev" {
+		if viper.GetBool("no-update-check") || version.Version == "dev" {
+			return
+		}
+		if shouldSuppressInformationalOutput(cmd, output.FormatAuto) {
 			return
 		}
 		if result := updatecheck.Check(version.Version); result != nil {


### PR DESCRIPTION
## What does this PR do?
Suppress update check notifications for non-interactive and machine-readable CLI commands to ensure clean output for automation use cases.

<!-- Explain the change in your own words. Be specific — what behavior changed, what was added, what was removed? -->
<!-- A reviewer who reads only this section should understand the full scope of the change. -->

## Related Issue
Closes #955

## Why?
This PR updates the CLI to skip update check notifications when commands are executed in non-interactive or machine-readable contexts.

Previously, the global PersistentPostRun hook would trigger update checks for most commands, which could emit update notices to stderr even when the CLI was used in scripts or pipelines.

<!-- What motivated this change? What problem does it solve? Why this approach over alternatives? -->
<!-- If you considered other approaches, briefly mention why you didn't go with them. -->

## How it works
The update check in PersistentPostRun is now conditionally skipped using shouldSuppressInformationalOutput, which detects non-interactive or machine-readable output (e.g., JSON, CSV, pipes).

<!-- Walk through the technical approach. Mention key files, functions, or design decisions. -->
<!-- If the change touches multiple layers (e.g., backend + frontend), explain each. -->

## How was this tested?
I tested manually across interactive scenarios, including JSON/CSV output, piped and redirected commands, and TUI mode. 

<!-- Describe what you did to verify the change works. Include: -->
<!-- - Manual testing steps you performed --> 
<!-- - Any new or updated automated tests -->
<!-- - Edge cases you considered -->

## Screenshots / recordings

<!-- If this PR changes UI, include before/after screenshots or a short recording. -->
<!-- Delete this section if not applicable. -->

## Checklist

- [X] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] My PR description is written in my own words and accurately describes my changes
- [X] I have tested my changes locally
- [X] I have not included build artifacts or unrelated changes

