### PR TITLE
feat: bookmarks search

### DIFF
--- a/cli/cmd/bookmarks.go
+++ b/cli/cmd/bookmarks.go
@@ -39,7 +39,8 @@ Subcommands:
   list    List saved bookmarks
   save    Save a bookmark from SQL text
   load    Print a saved bookmark's SQL
-  delete  Remove a saved bookmark`,
+  delete  Remove a saved bookmark
+  search  Search saved bookmarks`,
 }
 
 var bookmarksListCmd = &cobra.Command{
@@ -213,6 +214,54 @@ var bookmarksDeleteCmd = &cobra.Command{
 	},
 }
 
+var bookmarksSearchCmd = &cobra.Command{
+	Use:           "search [name]",
+	Short:         "Search saved bookmarks`",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	Args:          cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		format, err := output.ParseFormat(bookmarkFormat)
+		if err != nil {
+			return err
+		}
+		quiet := bookmarkQuiet || shouldSuppressInformationalOutput(cmd, format)
+		out := newCommandOutput(cmd, format, quiet)
+
+		cfg, err := config.LoadConfig()
+		if err != nil {
+			return fmt.Errorf("cannot load config: %w", err)
+		}
+
+		bookmarks := cfg.GetSavedQueries()
+
+		rows := make([][]any, 0)
+		pattern := strings.ToLower(args[0])
+		for _, value := range bookmarks {
+			if strings.Contains(strings.ToLower(value.Name), pattern) ||
+				strings.Contains(strings.ToLower(value.Query), pattern) {
+				rows = append(rows, []any{value.Name, strings.ReplaceAll(value.Query, "\n", " ")})
+			}
+		}
+
+		if len(rows) == 0 {
+			out.Info("No matching bookmarks found for: %s", args[0])
+			if effectiveCommandOutputFormat(cmd, format) == output.FormatJSON {
+				return writeEmptyJSONArray(cmd)
+			}
+			return nil
+		}
+
+		return out.WriteQueryResult(&output.QueryResult{
+			Columns: []output.Column{
+				{Name: "name", Type: "string"},
+				{Name: "query", Type: "string"},
+			},
+			Rows: rows,
+		})
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(bookmarksCmd)
 
@@ -220,8 +269,9 @@ func init() {
 	bookmarksCmd.AddCommand(bookmarksSaveCmd)
 	bookmarksCmd.AddCommand(bookmarksLoadCmd)
 	bookmarksCmd.AddCommand(bookmarksDeleteCmd)
+	bookmarksCmd.AddCommand(bookmarksSearchCmd)
 
-	for _, command := range []*cobra.Command{bookmarksListCmd, bookmarksSaveCmd, bookmarksDeleteCmd} {
+	for _, command := range []*cobra.Command{bookmarksListCmd, bookmarksSaveCmd, bookmarksDeleteCmd, bookmarksSearchCmd} {
 		command.Flags().StringVarP(&bookmarkFormat, "format", "f", "table", "output format: auto, table, plain, json, ndjson, or csv")
 		command.Flags().BoolVarP(&bookmarkQuiet, "quiet", "q", false, "suppress informational messages")
 		command.RegisterFlagCompletionFunc("format", completeOutputFormats)

--- a/cli/cmd/bookmarks.go
+++ b/cli/cmd/bookmarks.go
@@ -39,7 +39,8 @@ Subcommands:
   list    List saved bookmarks
   save    Save a bookmark from SQL text
   load    Print a saved bookmark's SQL
-  delete  Remove a saved bookmark`,
+  delete  Remove a saved bookmark
+  search  Search saved bookmarks`,
 }
 
 var bookmarksListCmd = &cobra.Command{
@@ -216,6 +217,54 @@ var bookmarksDeleteCmd = &cobra.Command{
 	},
 }
 
+var bookmarksSearchCmd = &cobra.Command{
+	Use:           "search [name]",
+	Short:         "Search saved bookmarks`",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	Args:          cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		format, err := output.ParseFormat(bookmarkFormat)
+		if err != nil {
+			return err
+		}
+		quiet := bookmarkQuiet || shouldSuppressInformationalOutput(cmd, format)
+		out := newCommandOutput(cmd, format, quiet)
+
+		cfg, err := config.LoadConfig()
+		if err != nil {
+			return fmt.Errorf("cannot load config: %w", err)
+		}
+
+		bookmarks := cfg.GetSavedQueries()
+
+		rows := make([][]any, 0)
+		pattern := strings.ToLower(args[0])
+		for _, value := range bookmarks {
+			if strings.Contains(strings.ToLower(value.Name), pattern) ||
+				strings.Contains(strings.ToLower(value.Query), pattern) {
+				rows = append(rows, []any{value.Name, strings.ReplaceAll(value.Query, "\n", " ")})
+			}
+		}
+
+		if len(rows) == 0 {
+			out.Info("No matching bookmarks found for: %s", args[0])
+			if effectiveCommandOutputFormat(cmd, format) == output.FormatJSON {
+				return writeEmptyJSONArray(cmd)
+			}
+			return nil
+		}
+
+		return out.WriteQueryResult(&output.QueryResult{
+			Columns: []output.Column{
+				{Name: "name", Type: "string"},
+				{Name: "query", Type: "string"},
+			},
+			Rows: rows,
+		})
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(bookmarksCmd)
 
@@ -223,8 +272,9 @@ func init() {
 	bookmarksCmd.AddCommand(bookmarksSaveCmd)
 	bookmarksCmd.AddCommand(bookmarksLoadCmd)
 	bookmarksCmd.AddCommand(bookmarksDeleteCmd)
+	bookmarksCmd.AddCommand(bookmarksSearchCmd)
 
-	for _, command := range []*cobra.Command{bookmarksListCmd, bookmarksSaveCmd, bookmarksDeleteCmd} {
+	for _, command := range []*cobra.Command{bookmarksListCmd, bookmarksSaveCmd, bookmarksDeleteCmd, bookmarksSearchCmd} {
 		command.Flags().StringVarP(&bookmarkFormat, "format", "f", "table", "output format: auto, table, plain, json, ndjson, or csv")
 		command.Flags().BoolVarP(&bookmarkQuiet, "quiet", "q", false, "suppress informational messages")
 		command.RegisterFlagCompletionFunc("format", completeOutputFormats)

--- a/cli/cmd/bookmarks.go
+++ b/cli/cmd/bookmarks.go
@@ -147,7 +147,7 @@ var bookmarksLoadCmd = &cobra.Command{
 		for _, saved := range cfg.GetSavedQueries() {
 			if saved.Name == args[0] {
 				copy := saved
-				bookmark = new(copy)
+				bookmark = &copy
 				break
 			}
 		}
@@ -159,12 +159,9 @@ var bookmarksLoadCmd = &cobra.Command{
 			return writeCommandJSON(cmd, bookmark)
 		}
 
-		if effectiveCommandOutputFormat(cmd, format) == output.FormatNDJSON {
-			return writeCommandNDJSON(cmd, []*config.SavedQuery{bookmark})
-		}
-
 		if effectiveCommandOutputFormat(cmd, format) == output.FormatTable ||
-			effectiveCommandOutputFormat(cmd, format) == output.FormatCSV {
+			effectiveCommandOutputFormat(cmd, format) == output.FormatCSV ||
+			effectiveCommandOutputFormat(cmd, format) == output.FormatNDJSON {
 			out := newCommandOutput(cmd, format, true)
 			return out.WriteQueryResult(&output.QueryResult{
 				Columns: []output.Column{
@@ -219,7 +216,7 @@ var bookmarksDeleteCmd = &cobra.Command{
 
 var bookmarksSearchCmd = &cobra.Command{
 	Use:           "search [name]",
-	Short:         "Search saved bookmarks`",
+	Short:         "Search saved bookmarks",
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Args:          cobra.ExactArgs(1),
@@ -240,10 +237,15 @@ var bookmarksSearchCmd = &cobra.Command{
 
 		rows := make([][]any, 0)
 		pattern := strings.ToLower(args[0])
+		effFormat := effectiveCommandOutputFormat(cmd, format)
 		for _, value := range bookmarks {
 			if strings.Contains(strings.ToLower(value.Name), pattern) ||
 				strings.Contains(strings.ToLower(value.Query), pattern) {
-				rows = append(rows, []any{value.Name, strings.ReplaceAll(value.Query, "\n", " ")})
+				query := value.Query
+				if effFormat != output.FormatJSON && effFormat != output.FormatNDJSON && effFormat != output.FormatCSV {
+					query = strings.ReplaceAll(query, "\n", " ")
+				}
+				rows = append(rows, []any{value.Name, query})
 			}
 		}
 

--- a/cli/cmd/programmatic_commands_test.go
+++ b/cli/cmd/programmatic_commands_test.go
@@ -1870,6 +1870,87 @@ func TestBookmarksLoadCmd_NDJSONMatchesJSONShape(t *testing.T) {
 	}
 }
 
+func TestBookmarksSearchCmd(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	bookmarkFormat = "json"
+	bookmarkQuiet = false
+
+	seed := []struct{ name, query string }{
+		{"get-str-table", "SELECT * FROM strtab"},
+		{"get-rec", "SELECT * FROM strtab"},
+		{"get-age", "SELECT age FROM strtab"},
+		{"get-age-gt-ten", "SELECT age FROM strtab"},
+	}
+	for _, s := range seed {
+		saveOut, saveErr := setCommandBuffers(t, bookmarksSaveCmd)
+		if err := bookmarksSaveCmd.RunE(bookmarksSaveCmd, []string{s.name, s.query}); err != nil {
+			t.Fatalf("bookmarks save failed: %v", err)
+		}
+		saveEnvelope := decodeJSONEnvelope[config.SavedQuery](t, saveOut)
+		if saveEnvelope.Command != "bookmarks.save" {
+			t.Fatalf("expected bookmarks.save command, got %q", saveEnvelope.Command)
+		}
+		if saveErr.Len() != 0 {
+			t.Fatalf("expected no stderr from save, got %q", saveErr.String())
+		}
+	}
+
+	t.Run("name_and_query_match", func(t *testing.T) {
+		bookmarkFormat = "json"
+		out, errBuf := setCommandBuffers(t, bookmarksSearchCmd)
+		if err := bookmarksSearchCmd.RunE(bookmarksSearchCmd, []string{"age"}); err != nil {
+			t.Fatalf("bookmarks search failed: %v", err)
+		}
+		var results []struct {
+			Name  string `json:"name"`
+			Query string `json:"query"`
+		}
+		if err := json.Unmarshal(out.Bytes(), &results); err != nil {
+			t.Fatalf("failed to decode search json output: %v", err)
+		}
+		if len(results) != 2 {
+			t.Fatalf("expected 2 matches for 'age', got %d: %+v", len(results), results)
+		}
+		if errBuf.Len() != 0 {
+			t.Fatalf("expected no stderr from search, got %q", errBuf.String())
+		}
+	})
+
+	t.Run("query-only_match_returns_all", func(t *testing.T) {
+		bookmarkFormat = "json"
+		out, errBuf := setCommandBuffers(t, bookmarksSearchCmd)
+		if err := bookmarksSearchCmd.RunE(bookmarksSearchCmd, []string{"SELECT"}); err != nil {
+			t.Fatalf("bookmarks search failed: %v", err)
+		}
+		var results []struct {
+			Name  string `json:"name"`
+			Query string `json:"query"`
+		}
+		if err := json.Unmarshal(out.Bytes(), &results); err != nil {
+			t.Fatalf("failed to decode search json output: %v", err)
+		}
+		if len(results) != 4 {
+			t.Fatalf("expected 4 matches for 'SELECT', got %d: %+v", len(results), results)
+		}
+		if errBuf.Len() != 0 {
+			t.Fatalf("expected no stderr from search, got %q", errBuf.String())
+		}
+	})
+
+	t.Run("no_match_returns_empty_array", func(t *testing.T) {
+		bookmarkFormat = "json"
+		out, _ := setCommandBuffers(t, bookmarksSearchCmd)
+		if err := bookmarksSearchCmd.RunE(bookmarksSearchCmd, []string{"sdfds"}); err != nil {
+			t.Fatalf("bookmarks search failed: %v", err)
+		}
+		if strings.TrimSpace(out.String()) != "[]" {
+			t.Fatalf("expected empty json array, got %q", out.String())
+		}
+	})
+}
+
 func TestProfilesCmd_SaveShowDelete(t *testing.T) {
 	cleanup := setupTestEnv(t)
 	defer cleanup()


### PR DESCRIPTION
## Related Issue
Closes #959

## What does this PR do?
Adds a new whodb-cli bookmarks search [pattern] command to filter saved bookmarks by name and SQL query text.
<!-- Explain the change in your own words. Be specific — what behavior changed, what was added, what was removed? -->
<!-- A reviewer who reads only this section should understand the full scope of the change. -->

## Why?
Currently, users must scan all bookmarks manually using list. This becomes inefficient as the number of bookmarks grows. This feature enables quick lookup by name or query content.

<!-- What motivated this change? What problem does it solve? Why this approach over alternatives? -->
<!-- If you considered other approaches, briefly mention why you didn't go with them. -->

## How it works
The user can use this command by passing an arguement of a bookmark's name or query. The command filters from existing bookmarks and returns results. 

### Usage
`whodb-cli bookmarks search pattern`
<!-- Walk through the technical approach. Mention key files, functions, or design decisions. -->
<!-- If the change touches multiple layers (e.g., backend + frontend), explain each. -->

## How was this tested?
Manual testing:
```
./whodb-cli bookmarks list 
name    query
get-str-table   SELECT * FROM strtab
get-rec SELECT * FROM strtab
get-age SELECT age FROM strtab
get-age-gt-ten  SELECT age FROM strtab
```
```
whodb-cli bookmarks search age --format json
[
  {
    "name": "get-age",
    "query": "SELECT age FROM strtab"
  },
  {
    "name": "get-age-gt-ten",
    "query": "SELECT age FROM strtab"
  }
]
```
```
whodb-cli bookmarks search SELECT
name    query
get-str-table   SELECT * FROM strtab
get-rec SELECT * FROM strtab
get-age SELECT age FROM strtab
get-age-gt-ten  SELECT age FROM strtab
```

```
whodb-cli bookmarks search SELECT --format json
[
  {
    "name": "get-str-table",
    "query": "SELECT * FROM strtab"
  },
  {
    "name": "get-rec",
    "query": "SELECT * FROM strtab"
  },
  {
    "name": "get-age",
    "query": "SELECT age FROM strtab"
  },
  {
    "name": "get-age-gt-ten",
    "query": "SELECT age FROM strtab"
  }
]

```

```
./whodb-cli bookmarks search sdfds --format json
[]

```
<!-- Describe what you did to verify the change works. Include: -->
<!-- - Manual testing steps you performed -->
<!-- - Any new or updated automated tests -->
<!-- - Edge cases you considered -->

## Screenshots / recordings

<!-- If this PR changes UI, include before/after screenshots or a short recording. -->
<!-- Delete this section if not applicable. -->

## Checklist

- [X] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I discussed this change in an issue before starting work
- [X] My PR description is written in my own words and accurately describes my changes
- [X] I have tested my changes locally
- [X] I have not included build artifacts or unrelated changes

