### PR TITLE
Updated README.md for keybind consistency #954

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -895,7 +895,7 @@ Write and execute SQL queries with schema-aware autocomplete.
 | `Ctrl+Space` (`Ctrl+@`)     | Trigger autocomplete |
 | `↑/↓` or `Ctrl+P/N`         | Navigate suggestions |
 | `Enter`                     | Accept suggestion    |
-| `Ctrl+L`                    | Clear editor         |
+| `Alt+L`                    | Clear editor         |
 | `Tab`                       | Next view            |
 | `Esc`                       | Back to browser      |
 


### PR DESCRIPTION
## Related Issue

<!-- Link the issue this PR addresses. Every PR must reference an issue. -->
<!-- If no issue exists, open one first to discuss the change with maintainers. -->

Closes #954 

## What does this PR do?

This PR updates the CLI README to accurately reflect the editor mode keybinds: clearing the editor was listed as 'Ctrl+L' --> changed to 'Alt+L' as is reflected in `cli/tui/keymap.go:381`. 

## Why?

This PR aims to reduce confusion caused by the same keybind having different functionalities described in different pieces of documentation. 

## How it works

This is a documentation change, it has no effect on code execution. 

## How was this tested?

N/A, only changed documentation.


## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I discussed this change in an issue before starting work
- [x] My PR description is written in my own words and accurately describes my changes
- [x] I have tested my changes locally
- [x] I have not included build artifacts or unrelated changes

### AI disclosure

- [ ] I used AI tools (e.g., Copilot, ChatGPT, Claude) to help write code in this PR

<!-- If you checked the box above, confirm the following: -->
<!-- - [ ] I understand every line of code in this PR and can explain any part of it -->
<!-- - [ ] The PR description above was written by me, not generated by AI -->
<!-- - [ ] I have reviewed all AI-generated code for correctness, security, and adherence to project conventions -->
