### PR TITLE
Add CLI history load command

### DIFF
--- a/cli/cmd/history.go
+++ b/cli/cmd/history.go
@@ -40,6 +40,7 @@ var historyCmd = &cobra.Command{
 Subcommands:
   list   - List recent queries
   search - Search queries by pattern
+  load   - Print the full query for a history entry
   clear  - Clear all history`,
 	Example: `  # List recent queries
   whodb-cli history list
@@ -49,6 +50,9 @@ Subcommands:
 
   # Search for queries containing "users"
   whodb-cli history search users
+
+  # Print the full query for a history entry
+  whodb-cli history load 1712345678901234567
 
   # Clear all history
   whodb-cli history clear`,
@@ -230,6 +234,58 @@ var historySearchCmd = &cobra.Command{
 	},
 }
 
+var historyLoadCmd = &cobra.Command{
+	Use:           "load [id]",
+	Short:         "Print the full query for a history entry",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	Args:          cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		format, err := output.ParseFormat(historyFormat)
+		if err != nil {
+			return err
+		}
+		mgr, err := history.NewManager()
+		if err != nil {
+			return fmt.Errorf("cannot load history: %w", err)
+		}
+		entry, err := mgr.Get(args[0])
+		if err != nil {
+			return fmt.Errorf("history entry %q not found", args[0])
+		}
+		effectiveFormat := effectiveCommandOutputFormat(cmd, format)
+		if format == output.FormatAuto {
+			effectiveFormat = output.FormatPlain
+		}
+		if effectiveFormat == output.FormatJSON {
+			return writeCommandJSON(cmd, entry)
+		}
+		if effectiveFormat == output.FormatTable ||
+			effectiveFormat == output.FormatCSV ||
+			effectiveFormat == output.FormatNDJSON {
+			out := newCommandOutput(cmd, effectiveFormat, true)
+			return out.WriteQueryResult(&output.QueryResult{
+				Columns: []output.Column{
+					{Name: "id", Type: "string"},
+					{Name: "timestamp", Type: "string"},
+					{Name: "database", Type: "string"},
+					{Name: "success", Type: "bool"},
+					{Name: "query", Type: "string"},
+				},
+				Rows: [][]any{{
+					entry.ID,
+					entry.Timestamp.Format("2006-01-02 15:04:05"),
+					entry.Database,
+					entry.Success,
+					entry.Query,
+				}},
+			})
+		}
+		_, err = fmt.Fprintln(cmd.OutOrStdout(), entry.Query)
+		return err
+	},
+}
+
 var historyClearCmd = &cobra.Command{
 	Use:           "clear",
 	Short:         "Clear all query history",
@@ -276,6 +332,7 @@ func init() {
 	// Subcommands
 	historyCmd.AddCommand(historyListCmd)
 	historyCmd.AddCommand(historySearchCmd)
+	historyCmd.AddCommand(historyLoadCmd)
 	historyCmd.AddCommand(historyClearCmd)
 
 	historyCmd.RegisterFlagCompletionFunc("format", completeOutputFormats)

--- a/cli/cmd/programmatic_commands_test.go
+++ b/cli/cmd/programmatic_commands_test.go
@@ -1443,6 +1443,7 @@ func TestHistoryCmd_HasSubcommands(t *testing.T) {
 	subcommands := map[string]bool{
 		"list":   false,
 		"search": false,
+		"load":   false,
 		"clear":  false,
 	}
 
@@ -1500,6 +1501,106 @@ func TestHistorySearchCmd_RequiresPattern(t *testing.T) {
 	err := historySearchCmd.Args(historySearchCmd, []string{})
 	if err == nil {
 		t.Error("Expected error when pattern is not provided")
+	}
+}
+
+func TestHistoryLoadCmd_PrintsFullQuery(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	query := "SELECT id, name, email, created_at, updated_at\nFROM users\nWHERE email LIKE '%@example.com'\nORDER BY created_at DESC"
+	mgr, err := history.NewManager()
+	if err != nil {
+		t.Fatalf("Failed to create history manager: %v", err)
+	}
+	if err := mgr.Add(query, true, "sqlite"); err != nil {
+		t.Fatalf("Failed to add history entry: %v", err)
+	}
+	entries := mgr.GetAll()
+	if len(entries) != 1 {
+		t.Fatalf("Expected 1 history entry, got %d", len(entries))
+	}
+	historyFormat = "plain"
+	historyQuiet = false
+
+	outBuf, errBuf := setCommandBuffers(t, historyLoadCmd)
+	if err := historyLoadCmd.RunE(historyLoadCmd, []string{entries[0].ID}); err != nil {
+		t.Fatalf("History load failed: %v", err)
+	}
+	if outBuf.String() != query+"\n" {
+		t.Fatalf("Expected full query output, got %q", outBuf.String())
+	}
+	if errBuf.Len() != 0 {
+		t.Fatalf("Expected no stderr output, got %q", errBuf.String())
+	}
+}
+
+func TestHistoryLoadCmd_JSON(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	query := "SELECT * FROM users WHERE notes = 'full history entry'"
+	mgr, err := history.NewManager()
+	if err != nil {
+		t.Fatalf("Failed to create history manager: %v", err)
+	}
+	if err := mgr.Add(query, false, "postgres"); err != nil {
+		t.Fatalf("Failed to add history entry: %v", err)
+	}
+	entries := mgr.GetAll()
+	if len(entries) != 1 {
+		t.Fatalf("Expected 1 history entry, got %d", len(entries))
+	}
+	historyFormat = "json"
+	historyQuiet = false
+
+	outBuf, errBuf := setCommandBuffers(t, historyLoadCmd)
+	if err := historyLoadCmd.RunE(historyLoadCmd, []string{entries[0].ID}); err != nil {
+		t.Fatalf("History load failed: %v", err)
+	}
+	var loaded history.Entry
+	if err := json.Unmarshal(outBuf.Bytes(), &loaded); err != nil {
+		t.Fatalf("Failed to parse history entry JSON: %v", err)
+	}
+
+	if loaded.ID != entries[0].ID {
+		t.Fatalf("Expected ID %q, got %q", entries[0].ID, loaded.ID)
+	}
+	if loaded.Query != query {
+		t.Fatalf("Expected query %q, got %q", query, loaded.Query)
+	}
+	if loaded.Success {
+		t.Fatalf("Expected success to be false")
+	}
+	if loaded.Database != "postgres" {
+		t.Fatalf("Expected database postgres, got %q", loaded.Database)
+	}
+	if errBuf.Len() != 0 {
+		t.Fatalf("Expected no stderr output, got %q", errBuf.String())
+	}
+}
+
+func TestHistoryLoadCmd_MissingID(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	historyFormat = "plain"
+	historyQuiet = false
+
+	outBuf, errBuf := setCommandBuffers(t, historyLoadCmd)
+	err := historyLoadCmd.RunE(historyLoadCmd, []string{"missing-id"})
+	if err == nil {
+		t.Fatal("Expected missing history entry error")
+	}
+
+	if !strings.Contains(err.Error(), `history entry "missing-id" not found`) {
+		t.Fatalf("Expected clear missing ID error, got %q", err.Error())
+	}
+	if outBuf.Len() != 0 {
+		t.Fatalf("Expected no stdout output, got %q", outBuf.String())
+	}
+	if errBuf.Len() != 0 {
+		t.Fatalf("Expected no stderr output, got %q", errBuf.String())
 	}
 }
 


### PR DESCRIPTION
## Related Issue

Fixes #960 

Closes #960 

## What does this PR do?

This PR adds a new `whodb-cli history load [id]` command that outputs the full SQL query for a single history entry. The current history table can truncate long queries, so this gives users a way to recover the exact query by ID.

## Why?

Implemented a dedicated `load` subcommand because it matches the existing CLI pattern for loading one saved item and keeps list/search output unchanged.

## How it works

The new command implemented in `cli/cmd/history.go` loads the existing history manager, looks up the requested entry by ID using the existing history manager lookup, and then outputs based on the requested format. 
Plain/default output prints only the query text for direct shell use. JSON output writes the full history entry. Table, CSV, and NDJSON output render one untruncated entry row where practical.

Also, for missing or invalid IDs it either exits asking for valid arguments or outputs invalid in case of invalid ID.

## How was this tested?

Automated tests:
  - `go test ./cmd -run "TestHistory"`
  - `go test ./internal/history`
  
Manual Testing:
Seeded a history entry with multiline SQL query.
Results:
```
whodb-cli history load manual-history-load-test
SELECT id, name, email FROM users
WHERE email LIKE '%@example.com'
ORDER BY
  created_at DESC

whodb-cli history load manual-history-load-test --format json
{
  "id": "manual-history-load-test",
  "query": "SELECT id, name, email FROM users\nWHERE email LIKE '%@example.com'\nORDER BY\n  created_at DESC",
  "success": true,
  "timestamp": "2026-05-05T15:32:43.9813565Z",
  "database": "manual"
}

whodb-cli history load missing-id
Error: history entry "missing-id" not found
exit status 1
```

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I discussed this change in an issue before starting work
- [x] My PR description is written in my own words and accurately describes my changes
- [x] I have tested my changes locally
- [x] I have not included build artifacts or unrelated changes

Let me know if there are any corrections or further fixes to make in this PR.