### PR TITLE
fix: wire desktop import data action through Wails menu

### DIFF
--- a/desktop-common/app.go
+++ b/desktop-common/app.go
@@ -378,6 +378,9 @@ func (a *App) SetupApplicationMenu() {
 	fileMenu.AddText("Export Data", keys.Combo("e", keys.CmdOrCtrlKey, keys.ShiftKey), func(_ *menu.CallbackData) {
 		runtime.EventsEmit(a.ctx, "menu:export-data")
 	})
+	fileMenu.AddText("Import Data", keys.CmdOrCtrl("i"), func(_ *menu.CallbackData) {
+		runtime.EventsEmit(a.ctx, "menu:import-data")
+	})
 	fileMenu.AddSeparator()
 	fileMenu.AddText("Quit", keys.CmdOrCtrl("q"), func(_ *menu.CallbackData) {
 		runtime.Quit(a.ctx)

--- a/frontend/src/hooks/useDesktop.ts
+++ b/frontend/src/hooks/useDesktop.ts
@@ -151,6 +151,11 @@ export const useDesktopMenu = () => {
         // Emit custom event that the table component can listen to
         window.dispatchEvent(new CustomEvent('menu:trigger-export'));
       }),
+      'menu:import-data': safeHandler(() => {
+        // Emit custom event that the table component can listen to
+        window.dispatchEvent(new CustomEvent('menu:trigger-import'));
+      }),
+
       'menu:refresh': safeHandler(() => {
         // Emit refresh event instead of page reload for HashRouter compatibility
         window.dispatchEvent(new CustomEvent('app:refresh-data'));


### PR DESCRIPTION
## Related Issue

Closes https://github.com/clidey/whodb/issues/952


## What does this PR do?

Adds an "Import Data" menu item to the native Wails File menu and wires the event bridge so it triggers the frontend import dialog. This mirrors the existing "Export Data" menu item.

## Why?

The frontend already handles import via a keyboard shortcut (`Ctrl+I`) and an in-app button, but the native desktop menu had no corresponding entry. Export had full parity (menu item + event bridge), import did not.

## How it works

Two files changed:

- **`desktop-common/app.go`**: Added `"Import Data"` entry in the File menu with `Ctrl+I` accelerator. On click, it emits a `"menu:import-data"` Wails event.
- **`frontend/src/hooks/useDesktop.ts`**: Added a handler for `"menu:import-data"` that dispatches a `CustomEvent('menu:trigger-import')` to the window. The table component already listens for this event.

## How was this tested?

- Ran `go build ./cmd/whodb`
- Ran `pnpm run build:ce`
- Tested the desktop app locally, confirmed that the desktop shortcuts and menu actions opens the import dialog on a table view and successfully imported a CSV file.

## Screenshots / recordings

N/A

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I discussed this change in an issue before starting work
- [x] My PR description is written in my own words and accurately describes my changes
- [x] I have tested my changes locally
- [x] I have not included build artifacts or unrelated changes

### AI disclosure

- [ ] I used AI tools (e.g., Copilot, ChatGPT, Claude) to help write code in this PR

