### PR TITLE
feat: search keyboard shortcut modal

### DIFF
--- a/frontend/src/components/keyboard-shortcuts-help.tsx
+++ b/frontend/src/components/keyboard-shortcuts-help.tsx
@@ -159,7 +159,7 @@ export const KeyboardShortcutsHelp: FC<KeyboardShortcutsHelpProps> = ({
                     <DialogTitle className="flex items-center gap-2">
                         {t('title')}
                     </DialogTitle>
-                    <SearchInput className="mt-2" value={searchFilter} onChange={e => setSearchFilter(e.target.value)} placeholder={t('Type a Shortcut or search...')} />
+                    <SearchInput className="mt-2" value={searchFilter} onChange={e => setSearchFilter(e.target.value)} placeholder={'Type a Shortcut or search...'} />
                 </DialogHeader>
                 <div className="mt-4">
                     {filteredShortcuts.length > 0 ?
@@ -173,7 +173,7 @@ export const KeyboardShortcutsHelp: FC<KeyboardShortcutsHelpProps> = ({
                     : 
                     (
                         <p className="text-sm text-muted-foreground text-center py-4">
-                            {t('noShortcutsFound')}
+                            "No shortcuts found"
                         </p>
                     )}
                     

--- a/frontend/src/components/keyboard-shortcuts-help.tsx
+++ b/frontend/src/components/keyboard-shortcuts-help.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import {Dialog, DialogContent, DialogHeader, DialogTitle,} from "@clidey/ux";
-import {FC, useCallback, useEffect, useState} from "react";
+import {Dialog, DialogContent, DialogHeader, DialogTitle, SearchInput,} from "@clidey/ux";
+import {FC, useCallback, useEffect, useState, useMemo} from "react";
 import {useTranslation} from "@/hooks/use-translation";
-import {getKeyDisplay, getEffectiveIsMac} from "@/utils/platform";
+import {getKeyDisplay, getEffectiveIsMac, formatShortcut} from "@/utils/platform";
 import {matchesShortcut, resolveShortcut, SHORTCUTS} from "@/utils/shortcuts";
 
 interface ShortcutEntry {
@@ -77,6 +77,7 @@ export const KeyboardShortcutsHelp: FC<KeyboardShortcutsHelpProps> = ({
     onOpenChange,
 }) => {
     const { t } = useTranslation('components/keyboard-shortcuts-help');
+    const [searchFilter, setSearchFilter] = useState("");
 
     const shortcutCategories: ShortcutCategory[] = [
         {
@@ -140,6 +141,16 @@ export const KeyboardShortcutsHelp: FC<KeyboardShortcutsHelpProps> = ({
             ],
         },
     ];
+    const filteredShortcuts = useMemo(() => {
+        const lowerCaseFilterValue = searchFilter.toLowerCase();
+
+        return shortcutCategories.map(shortcutCategory => ({
+            ...shortcutCategory,
+            shortcuts: shortcutCategory.shortcuts.filter(shortcut => shortcut.description.toLowerCase().includes(lowerCaseFilterValue) ||
+                                                                     formatShortcut(shortcut.keys).toLowerCase().includes(lowerCaseFilterValue))
+            })).filter(category => category.shortcuts.length > 0)
+
+    }, [searchFilter, shortcutCategories]);
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
@@ -148,15 +159,24 @@ export const KeyboardShortcutsHelp: FC<KeyboardShortcutsHelpProps> = ({
                     <DialogTitle className="flex items-center gap-2">
                         {t('title')}
                     </DialogTitle>
+                    <SearchInput className="mt-2" value={searchFilter} onChange={e => setSearchFilter(e.target.value)} placeholder={t('Type a Shortcut or search...')} />
                 </DialogHeader>
                 <div className="mt-4">
-                    {shortcutCategories.map((category, idx) => (
+                    {filteredShortcuts.length > 0 ?
+                    ( filteredShortcuts.map((category, idx) => (
                         <ShortcutSection
                             key={idx}
                             category={category}
                             testId={`shortcuts-category-${category.title.toLowerCase().replace(/\s+/g, '-')}`}
                         />
-                    ))}
+                    )))
+                    : 
+                    (
+                        <p className="text-sm text-muted-foreground text-center py-4">
+                            {t('noShortcutsFound')}
+                        </p>
+                    )}
+                    
                 </div>
                 <div className="mt-4 pt-4 border-t border-neutral-200 dark:border-neutral-700">
                     <p className="text-xs text-muted-foreground text-center">


### PR DESCRIPTION
## Related Issue

<!-- Link the issue this PR addresses. Every PR must reference an issue. -->
<!-- If no issue exists, open one first to discuss the change with maintainers. -->

Closes #958

## What does this PR do?
#### This PR is a follow-up of PR [#973](https://github.com/clidey/whodb/pull/973)
Adds a searchable filter input to the keyboard shortcuts modal to filter shortcuts by description and displayed key text.

<!-- Explain the change in your own words. Be specific — what behavior changed, what was added, what was removed? -->
<!-- A reviewer who reads only this section should understand the full scope of the change. -->

## Why?
The shortcuts modal becomes difficult to navigate as more shortcuts are added, so search improves discoverability and usability.

<!-- What motivated this change? What problem does it solve? Why this approach over alternatives? -->
<!-- If you considered other approaches, briefly mention why you didn't go with them. -->

## How it works
Adds local client-side filtering in frontend/src/components/keyboard-shortcuts-help.tsx using the existing SearchInput and .includes() filtering pattern.
<!-- Walk through the technical approach. Mention key files, functions, or design decisions. -->
<!-- If the change touches multiple layers (e.g., backend + frontend), explain each. -->

## How was this tested?
Manually tested shortcut filtering by descriptions and displayed keys.
<!-- Describe what you did to verify the change works. Include: -->
<!-- - Manual testing steps you performed -->
<!-- - Any new or updated automated tests -->
<!-- - Edge cases you considered -->

## Screenshots / recordings
<img width="1919" height="870" alt="image" src="https://github.com/user-attachments/assets/758ca5ba-df28-4368-aeb3-9bdb79c0bcd5" />


<img width="1919" height="863" alt="image" src="https://github.com/user-attachments/assets/67b1ca52-4eb7-480e-93db-4122c6f5978c" />


<img width="1919" height="850" alt="image" src="https://github.com/user-attachments/assets/1aecb6e5-32ee-4f0e-a99d-f87407e2dc43" />

<!-- If this PR changes UI, include before/after screenshots or a short recording. -->
<!-- Delete this section if not applicable. -->

## Checklist

- [X] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I discussed this change in an issue before starting work
- [X] My PR description is written in my own words and accurately describes my changes
- [X] I have tested my changes locally
- [X] I have not included build artifacts or unrelated changes

