### PR TITLE
fix: desktop login hashrouter safe

### DIFF
--- a/frontend/src/components/error-boundary.tsx
+++ b/frontend/src/components/error-boundary.tsx
@@ -18,7 +18,8 @@ import {Button} from "@clidey/ux";
 import {Component, type ErrorInfo, type ReactNode} from "react";
 import {captureException} from "../config/posthog";
 import {withBasePath} from "../utils/base-path";
-import {openExternalLink} from "../utils/external-links";
+import {isDesktopApp, openExternalLink} from "../utils/external-links";
+
 
 interface ErrorBoundaryProps {
     children: ReactNode;
@@ -45,7 +46,11 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     }
 
     private handleGoHome = () => {
-        window.location.href = withBasePath("/");
+        if (isDesktopApp()) {
+            window.location.hash = '/';
+        } else {
+            window.location.href = withBasePath("/");
+        }
     };
 
     render() {

--- a/frontend/src/config/graphql-client.ts
+++ b/frontend/src/config/graphql-client.ts
@@ -35,6 +35,7 @@ import {isAwsHostname, isAzureHostname, isGcpHostname} from '../utils/cloud-conn
 import {getTranslation, loadTranslationsSync} from '../utils/i18n';
 import {type SupportedLanguage, DEFAULT_LANGUAGE} from '../utils/languages';
 import {clearSourceSessionMetadata} from '../utils/source-session-metadata-cache';
+import { isDesktopApp } from '@/utils/external-links';
 
 // Always use an application-relative URI so that:
 // - Desktop/Wails uses the embedded router handler
@@ -70,7 +71,11 @@ const redirectToLoginWithMessage = (
 ) => {
     const t = translator ?? getTranslator();
     toast.error(t(key));
-    window.location.href = withBasePath('/login');
+    if (isDesktopApp()) {
+        window.location.hash = '/login';
+    } else {
+        window.location.href = withBasePath('/login');
+    }
 };
 
 const httpLink = new HttpLink({
@@ -115,7 +120,8 @@ const errorLink = onError(({error}) => {
 });
 
 function fallbackAutoLogin() {
-    if (window.location.pathname.startsWith(withBasePath('/login'))) {
+    if (window.location.pathname.startsWith(withBasePath('/login'))
+        || window.location.hash.startsWith('#/login')) {
         return;
     }
 


### PR DESCRIPTION
## Related Issue

<!-- Link the issue this PR addresses. Every PR must reference an issue. -->
<!-- If no issue exists, open one first to discuss the change with maintainers. -->

Closes #949

## What does this PR do?
Fixed the desktop app's login and home redirects to work correctly with HashRouter. Replaced raw window.location.href navigation and window.location.pathname route checks with HashRouter-safe alternatives using the existing isDesktopApp() helper
<!-- Explain the change in your own words. Be specific — what behavior changed, what was added, what was removed? -->
<!-- A reviewer who reads only this section should understand the full scope of the change. -->

## How it works
Three files were changed. The "Go home" button and login redirects now use window.location.hash on desktop instead of window.location.href. The login route check in fallbackAutoLogin now also looks at window.location.hash so it correctly detects the login page on desktop.
<!-- Walk through the technical approach. Mention key files, functions, or design decisions. -->
<!-- If the change touches multiple layers (e.g., backend + frontend), explain each. -->

## How was this tested?
Manually tested on the desktop app by forcing the error boundary to always show and clicking "Go home", then verifying in DevTools that window.location.hash correctly showed #/ after navigation instead of being empty. 

<!-- Describe what you did to verify the change works. Include: -->
<!-- - Manual testing steps you performed -->
<!-- - Any new or updated automated tests -->
<!-- - Edge cases you considered -->

## Screenshots / recordings

<!-- If this PR changes UI, include before/after screenshots or a short recording. -->
<!-- Delete this section if not applicable. -->

## Checklist

- [X] I have read the [Contributing Guidelines](https://github.com/clidey/whodb/blob/main/CONTRIBUTING.md)
- [ ] I discussed this change in an issue before starting work
- [X] My PR description is written in my own words and accurately describes my changes
- [X] I have tested my changes locally
- [X] I have not included build artifacts or unrelated changes

