### PR TITLE
feat: json error preview

### DIFF
--- a/frontend/src/components/editor.tsx
+++ b/frontend/src/components/editor.tsx
@@ -385,13 +385,28 @@ export const CodeEditor: FC<ICodeEditorProps> = ({
         );
       }
       if (language === "json") {
+        let parsed: any = null;
+        let isValidJson = true;
+        try{
+          parsed = JSON.parse(value);
+        } catch (e) {
+          isValidJson = false;
+        }
+
         return (
           <div className="h-full bg-white p-4 pl-8 dark:bg-[#252526] dark:backdrop-blur-md overflow-y-auto">
-            <ReactJson
-              src={JSON.parse(value)}
-              theme={darkModeEnabled ? "bright" : undefined}
-              style={{ height: "100%", backgroundColor: "unset" }}
-            />
+            {isValidJson ? (
+              <ReactJson
+                src={parsed}
+                theme={darkModeEnabled ? "bright" : undefined}
+                style={{ height: "100%", backgroundColor: "unset" }}
+              />
+            ) : (
+              <div className="flex flex-col items-center justify-center h-full gap-2">
+                  <p className="text-sm text-red-500 font-medium">Invalid JSON</p>
+                  <p className="text-xs text-muted-foreground">Please check your syntax and try again.</p>
+              </div>
+            )}
           </div>
         );
       }


### PR DESCRIPTION
## Related Issue

<!-- Link the issue this PR addresses. Every PR must reference an issue. -->
<!-- If no issue exists, open one first to discuss the change with maintainers. -->

Closes #951

## What does this PR do?
The JSON preview in the editor no longer crashes the app when the input is invalid, it now shows an inline error message instead.
<!-- Explain the change in your own words. Be specific — what behavior changed, what was added, what was removed? -->
<!-- A reviewer who reads only this section should understand the full scope of the change. -->

## How it works
A readable inline error message is rendered in the preview area instead when an invalid JSON is previewed by user.
<!-- Walk through the technical approach. Mention key files, functions, or design decisions. -->
<!-- If the change touches multiple layers (e.g., backend + frontend), explain each. -->

## How was this tested?
Connected to a MongoDB database, opened the Add Row sheet, entered invalid JSON, clicked Show Preview and confirmed the inline error message appears without crashing the app.

<!-- Describe what you did to verify the change works. Include: -->
<!-- - Manual testing steps you performed -->
<!-- - Any new or updated automated tests -->
<!-- - Edge cases you considered -->

## Screenshots / recordings
<img width="478" height="725" alt="image" src="https://github.com/user-attachments/assets/46c994da-fd35-49c7-a61d-8103338be246" />

<!-- If this PR changes UI, include before/after screenshots or a short recording. -->
<!-- Delete this section if not applicable. -->

## Checklist

- [X] I have read the [Contributing Guidelines](https://github.com/clidey/whodb/blob/main/CONTRIBUTING.md)
- [ ] I discussed this change in an issue before starting work
- [X] My PR description is written in my own words and accurately describes my changes
- [X] I have tested my changes locally
- [X] I have not included build artifacts or unrelated changes

