### PR TITLE
fix: health overlay logout

### DIFF
--- a/frontend/src/components/health/health-overlays.tsx
+++ b/frontend/src/components/health/health-overlays.tsx
@@ -19,7 +19,7 @@ import { createPortal } from 'react-dom';
 import { useTranslation } from '@/hooks/use-translation';
 import { useAppSelector } from '@/store/hooks';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { PublicRoutes } from '@/config/routes';
+import { InternalRoutes, PublicRoutes } from '@/config/routes';
 import { XCircleIcon } from '@heroicons/react/24/outline';
 import { useState } from 'react';
 import { LocalLoginProfile } from '@/store/auth';
@@ -159,7 +159,7 @@ export const DatabaseDownOverlay = () => {
     };
 
     const handleLogout = () => {
-        navigate(PublicRoutes.Login.path);
+        navigate(InternalRoutes.Logout.path);
     };
 
     return (


### PR DESCRIPTION
## Related Issue

<!-- Link the issue this PR addresses. Every PR must reference an issue. -->
<!-- If no issue exists, open one first to discuss the change with maintainers. -->

Closes #948

## What does this PR do?
The health overlay's logout button now navigates to /logout instead of /login directly
<!-- Explain the change in your own words. Be specific — what behavior changed, what was added, what was removed? -->
<!-- A reviewer who reads only this section should understand the full scope of the change. -->

## Why?
The overlay was bypassing the proper logout flow.
<!-- What motivated this change? What problem does it solve? Why this approach over alternatives? -->
<!-- If you considered other approaches, briefly mention why you didn't go with them. -->


## Checklist

- [X] I have read the [Contributing Guidelines](https://github.com/clidey/whodb/blob/main/CONTRIBUTING.md)
- [ ] I discussed this change in an issue before starting work
- [X] My PR description is written in my own words and accurately describes my changes
- [X] I have tested my changes locally
- [X] I have not included build artifacts or unrelated changes
