### PR TITLE
Add history load command

### DIFF
--- a/cli/cmd/history.go
+++ b/cli/cmd/history.go
@@ -40,6 +40,7 @@ var historyCmd = &cobra.Command{
 Subcommands:
   list   - List recent queries
   search - Search queries by pattern
+  load   - Print a saved query by ID
   clear  - Clear all history`,
 	Example: `  # List recent queries
   whodb-cli history list
@@ -49,6 +50,9 @@ Subcommands:
 
   # Search for queries containing "users"
   whodb-cli history search users
+
+  # Print the full query for a history entry
+  whodb-cli history load 1234567890
 
   # Clear all history
   whodb-cli history clear`,
@@ -230,6 +234,59 @@ var historySearchCmd = &cobra.Command{
 	},
 }
 
+var historyLoadCmd = &cobra.Command{
+	Use:           "load [id]",
+	Short:         "Print a saved query by ID",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	Args:          cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		format, err := output.ParseFormat(historyFormat)
+		if err != nil {
+			return err
+		}
+
+		mgr, err := history.NewManager()
+		if err != nil {
+			return fmt.Errorf("cannot load history: %w", err)
+		}
+
+		entry, err := mgr.Get(args[0])
+		if err != nil {
+			return fmt.Errorf("history entry %q not found: %w", args[0], err)
+		}
+
+		if effectiveCommandOutputFormat(cmd, format) == output.FormatJSON {
+			return writeCommandJSON(cmd, entry)
+		}
+
+		if effectiveCommandOutputFormat(cmd, format) == output.FormatTable ||
+			effectiveCommandOutputFormat(cmd, format) == output.FormatCSV ||
+			effectiveCommandOutputFormat(cmd, format) == output.FormatNDJSON {
+			out := newCommandOutput(cmd, format, true)
+			return out.WriteQueryResult(&output.QueryResult{
+				Columns: []output.Column{
+					{Name: "id", Type: "string"},
+					{Name: "timestamp", Type: "string"},
+					{Name: "database", Type: "string"},
+					{Name: "success", Type: "bool"},
+					{Name: "query", Type: "string"},
+				},
+				Rows: [][]any{{
+					entry.ID,
+					entry.Timestamp.Format("2006-01-02 15:04:05"),
+					entry.Database,
+					entry.Success,
+					entry.Query,
+				}},
+			})
+		}
+
+		_, err = fmt.Fprintln(cmd.OutOrStdout(), entry.Query)
+		return err
+	},
+}
+
 var historyClearCmd = &cobra.Command{
 	Use:           "clear",
 	Short:         "Clear all query history",
@@ -276,6 +333,7 @@ func init() {
 	// Subcommands
 	historyCmd.AddCommand(historyListCmd)
 	historyCmd.AddCommand(historySearchCmd)
+	historyCmd.AddCommand(historyLoadCmd)
 	historyCmd.AddCommand(historyClearCmd)
 
 	historyCmd.RegisterFlagCompletionFunc("format", completeOutputFormats)

--- a/cli/cmd/programmatic_commands_test.go
+++ b/cli/cmd/programmatic_commands_test.go
@@ -1443,6 +1443,7 @@ func TestHistoryCmd_HasSubcommands(t *testing.T) {
 	subcommands := map[string]bool{
 		"list":   false,
 		"search": false,
+		"load":   false,
 		"clear":  false,
 	}
 
@@ -1513,6 +1514,52 @@ func TestHistoryClearCmd_NoError(t *testing.T) {
 	err := historyClearCmd.RunE(historyClearCmd, []string{})
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestHistoryLoadCmd_PlainJSONAndMissingID(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	mgr, err := history.NewManager()
+	if err != nil {
+		t.Fatalf("Failed to create history manager: %v", err)
+	}
+	if err := mgr.Add("SELECT * FROM users", true, "sqlite"); err != nil {
+		t.Fatalf("Failed to add history entry: %v", err)
+	}
+	entry := mgr.GetAll()[0]
+
+	historyFormat = "plain"
+	outBuf, errBuf := setCommandBuffers(t, historyLoadCmd)
+	if err := historyLoadCmd.RunE(historyLoadCmd, []string{entry.ID}); err != nil {
+		t.Fatalf("history load failed: %v", err)
+	}
+	if strings.TrimSpace(outBuf.String()) != entry.Query {
+		t.Fatalf("unexpected loaded query %q", outBuf.String())
+	}
+	if errBuf.Len() != 0 {
+		t.Fatalf("expected no stderr from plain load, got %q", errBuf.String())
+	}
+
+	historyFormat = "json"
+	jsonOut, jsonErr := setCommandBuffers(t, historyLoadCmd)
+	if err := historyLoadCmd.RunE(historyLoadCmd, []string{entry.ID}); err != nil {
+		t.Fatalf("history load json failed: %v", err)
+	}
+	var loaded history.Entry
+	if err := json.Unmarshal(jsonOut.Bytes(), &loaded); err != nil {
+		t.Fatalf("failed to decode loaded history entry: %v", err)
+	}
+	if loaded.ID != entry.ID || loaded.Query != entry.Query || loaded.Database != entry.Database || !loaded.Success {
+		t.Fatalf("unexpected loaded history entry: %+v", loaded)
+	}
+	if jsonErr.Len() != 0 {
+		t.Fatalf("expected no stderr from json load, got %q", jsonErr.String())
+	}
+
+	if err := historyLoadCmd.RunE(historyLoadCmd, []string{"missing-id"}); err == nil || !strings.Contains(err.Error(), "entry \"missing-id\" not found") {
+		t.Fatalf("expected missing-id error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
- Add `whodb-cli history load [id]` to print a single history entry.
- Return a clear error when the ID is missing and support JSON output for automation.
