### PR TITLE
docs: add Requesty as an OpenAI-compatible provider example

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,12 @@ services:
       # - WHODB_AI_GENERIC_OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
       # - WHODB_AI_GENERIC_OPENROUTER_API_KEY=your_key_here
       # - WHODB_AI_GENERIC_OPENROUTER_MODELS=google/gemini-2.0-flash-001,anthropic/claude-3.5-sonnet
+      #
+      # Requesty example:
+      # - WHODB_AI_GENERIC_REQUESTY_NAME=Requesty
+      # - WHODB_AI_GENERIC_REQUESTY_BASE_URL=https://router.requesty.ai/v1
+      # - WHODB_AI_GENERIC_REQUESTY_API_KEY=your_key_here
+      # - WHODB_AI_GENERIC_REQUESTY_MODELS=openai/gpt-4o-mini,anthropic/claude-3.5-sonnet
     # volumes: # (Optional for SQLite)
     #   - ./sample.db:/db/sample.db
 ```
@@ -376,7 +382,7 @@ To enable natural language queries:
    WhoDB will auto-detect installed models and show a **Chat** option in the sidebar.
 
 2. **OpenAI/Anthropic** - Set environment variables (see Docker Compose example above)
-3. **Any OpenAI-compatible provider** - Use `WHODB_AI_GENERIC_<ID>_*` environment variables to connect to LM Studio, OpenRouter, or any provider with an OpenAI-compatible API (see Docker Compose example above)
+3. **Any OpenAI-compatible provider** - Use `WHODB_AI_GENERIC_<ID>_*` environment variables to connect to LM Studio, OpenRouter, Requesty, or any provider with an OpenAI-compatible API (see Docker Compose example above)
 
 #### 3. Start Backend Service
 
@@ -512,7 +518,7 @@ Yes! WhoDB integrates with:
 - **Ollama** - For local, private AI models
 - **OpenAI** - GPT-4 and other OpenAI models
 - **Anthropic** - Claude models
-- **Any OpenAI-compatible provider** - LM Studio, OpenRouter, vLLM, and more via `WHODB_AI_GENERIC_<ID>_*` environment variables
+- **Any OpenAI-compatible provider** - LM Studio, OpenRouter, Requesty, vLLM, and more via `WHODB_AI_GENERIC_<ID>_*` environment variables
 
 These integrations allow you to query your database using natural language instead of SQL.
 

--- a/docs/ai/setup-providers.mdx
+++ b/docs/ai/setup-providers.mdx
@@ -421,6 +421,12 @@ export WHODB_AI_GENERIC_OPENROUTER_BASE_URL="https://openrouter.ai/api/v1"
 export WHODB_AI_GENERIC_OPENROUTER_API_KEY="your_key_here"
 export WHODB_AI_GENERIC_OPENROUTER_MODELS="google/gemini-2.0-flash-001,anthropic/claude-3.5-sonnet"
 ```
+```bash Requesty (cloud)
+export WHODB_AI_GENERIC_REQUESTY_NAME="Requesty"
+export WHODB_AI_GENERIC_REQUESTY_BASE_URL="https://router.requesty.ai/v1"
+export WHODB_AI_GENERIC_REQUESTY_API_KEY="your_key_here"
+export WHODB_AI_GENERIC_REQUESTY_MODELS="openai/gpt-4o-mini,anthropic/claude-3.5-sonnet"
+```
 ```yaml Docker Compose
 services:
   whodb:


### PR DESCRIPTION
## Related Issue

No existing issue. This is a small docs-only addition that mirrors the already-documented OpenRouter example for `WHODB_AI_GENERIC_<ID>_*` providers. Happy to open a tracking issue if maintainers prefer.

## What does this PR do?

Adds Requesty as a worked example of an OpenAI-compatible provider configured through the `WHODB_AI_GENERIC_<ID>_*` environment variables, alongside the existing LM Studio and OpenRouter examples. No code changes.

Specifically:
- `docs/ai/setup-providers.mdx`: adds a `Requesty (cloud)` bash tab in the `<CodeGroup>` under "Custom Providers via Environment Variables", right after the OpenRouter tab, with `WHODB_AI_GENERIC_REQUESTY_NAME`, `_BASE_URL` (`https://router.requesty.ai/v1`), `_API_KEY`, and `_MODELS`.
- `README.md`: adds the parallel commented Requesty example next to the OpenRouter one in the Docker Compose env section, and adds "Requesty" to the two provider-list mentions ("LM Studio, OpenRouter, ...").

## Why?

Requesty is an OpenAI-compatible LLM gateway (base URL `https://router.requesty.ai/v1`, `provider/model` naming such as `openai/gpt-4o-mini`). It works with WhoDB's existing generic-provider mechanism without any code changes, so documenting it the same way OpenRouter is documented makes that path discoverable. I followed the existing OpenRouter example rather than introducing a new pattern to keep the docs consistent.

## How it works

WhoDB already supports any OpenAI-compatible endpoint via the `WHODB_AI_GENERIC_<ID>_*` variables (`NAME`, `TYPE`, `BASE_URL`, `API_KEY`, `MODELS`). The new example just sets `<ID>=REQUESTY` with Requesty's base URL and a couple of model IDs. The `_TYPE` is left at its `openai-generic` default, matching the OpenRouter example. No backend or frontend behavior changes — these are documentation strings only.

## How was this tested?

- Verified a live chat completion against `https://router.requesty.ai/v1/chat/completions` with model `openai/gpt-4o-mini` using `Authorization: Bearer <key>`; got HTTP 200 with a normal completion, confirming the base URL and `provider/model` naming used in the example are correct.
- Re-read both edited files to confirm the new blocks match the surrounding OpenRouter formatting (CodeGroup tab syntax in the mdx, comment style in the README).
- No automated tests apply since this is docs-only.

## Screenshots / recordings

Not applicable (docs-only change).

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/clidey/whodb/blob/main/CONTRIBUTING.md)
- [ ] I discussed this change in an issue before starting work
- [x] My PR description is written in my own words and accurately describes my changes
- [x] I have tested my changes locally
- [x] I have not included build artifacts or unrelated changes

### AI disclosure

- [ ] I used AI tools (e.g., Copilot, ChatGPT, Claude) to help write code in this PR

References: https://requesty.ai , https://docs.requesty.ai

I work at Requesty. This mirrors the existing OpenRouter example as closely as possible. Happy to adjust or close it if it's not a fit.
