### PR TITLE
fix: allow preconfigured profile login when credential form is disabled

### DIFF
--- a/core/graph/audit_batch_test.go
+++ b/core/graph/audit_batch_test.go
@@ -92,6 +92,34 @@ func TestPerformSourceLoginDisabledCredentialsEmitsDeniedAudit(t *testing.T) {
 	}
 }
 
+func TestPerformSourceLoginPreconfiguredProfileBypassesDisabledCredentials(t *testing.T) {
+	originalDisableCredentialForm := env.DisableCredentialForm
+	env.DisableCredentialForm = true
+	t.Cleanup(func() {
+		env.DisableCredentialForm = originalDisableCredentialForm
+	})
+
+	audit.SetAuditService(nil)
+	audit.SetActorProvider(nil)
+	t.Cleanup(func() {
+		audit.SetAuditService(nil)
+		audit.SetActorProvider(nil)
+	})
+
+	// A login originating from a preconfigured profile carries a non-empty
+	// profileSource and must not be rejected by the disabled credential form
+	// gate. An unknown source type is used so execution stops at the catalog
+	// lookup (returning "unauthorized") rather than attempting a real
+	// connection; the key assertion is that the gate did not reject it.
+	_, err := performSourceLogin(context.Background(), &source.Credentials{SourceType: "nonexistent-source"}, "environment")
+	if err == nil {
+		t.Fatal("expected an error for an unknown source type")
+	}
+	if err.Error() == "login with credentials is disabled; use preconfigured connections" {
+		t.Fatal("preconfigured profile login should bypass the disabled credential form gate")
+	}
+}
+
 func strPtr(value string) *string {
 	return &value
 }

--- a/core/graph/source_api.go
+++ b/core/graph/source_api.go
@@ -65,7 +65,11 @@ func performSourceLogin(ctx context.Context, credentials *source.Credentials, pr
 		})
 	}
 
-	if env.DisableCredentialForm {
+	// DisableCredentialForm only forbids logging in with manually entered
+	// credentials. Logins originating from a preconfigured profile (env vars,
+	// config file, cloud discovery) carry a non-empty profileSource and must
+	// still be allowed, otherwise enabling the flag makes login impossible.
+	if env.DisableCredentialForm && profileSource == "" {
 		log.WithField("sourceType", credentials.SourceType).Error("Login with credentials is disabled; use preconfigured connections")
 		err := errors.New("login with credentials is disabled; use preconfigured connections")
 		recordAudit(err)

--- a/core/src/src.go
+++ b/core/src/src.go
@@ -79,6 +79,7 @@ func GetLoginProfiles() []types.DatabaseCredentials {
 		for i := range databaseProfiles {
 			databaseProfiles[i].Type = databaseType
 			databaseProfiles[i].IsProfile = true
+			databaseProfiles[i].Source = "environment"
 			profiles = append(profiles, databaseProfiles[i])
 		}
 	}


### PR DESCRIPTION
## Problem

Setting `WHODB_DISABLE_CREDENTIAL_FORM=true` makes login **impossible**, including the preconfigured profiles it is meant to force users onto. Selecting a predefined profile (or the auto-login path) fails with:

```
login with credentials is disabled; use preconfigured connections
```

## Root cause

`LoginWithSourceProfile` routes through `performSourceLogin`, which rejects on `DisableCredentialForm` **before** considering `profileSource`:

```go
// core/graph/source_api.go
if env.DisableCredentialForm {
    return nil, errors.New("login with credentials is disabled; use preconfigured connections")
}
```

So both manual-credential logins **and** preconfigured-profile logins are blocked. There is no way to use the flag for its intended purpose.

A second, related issue: env-var database profiles (`WHODB_<TYPE>_N`) never set `Source`, unlike AWS/GCP/builtin profiles. So even a fixed gate couldn't distinguish them, and `IsEnvironmentDefined` was incorrectly `false` for them in `SourceProfiles`.

## Fix

1. Gate on `DisableCredentialForm && profileSource == ""`. Manual credential entry (`LoginSource` passes `profileSource=""`) stays blocked; logins resolved from a preconfigured profile proceed. `profileSource` is set server-side from the resolved profile, not from client input, so it can't be forged.
2. Env-var DB profiles now set `Source="environment"` (matching AWS/GCP/builtin), which also fixes `IsEnvironmentDefined`.

## Verification

Reproduced against a live 0.117.0 deployment: `SourceProfiles` returned the env profile, but `LoginWithSourceProfile` was rejected by the gate. Bug also present on `main`.

- `go build ./...` clean
- `go test ./graph/ ./src/` pass
- Added `TestPerformSourceLoginPreconfiguredProfileBypassesDisabledCredentials`; existing `TestPerformSourceLoginDisabledCredentialsEmitsDeniedAudit` (manual creds still blocked) still passes.