### PR TITLE
Add MiniMax as a built-in AI provider

### DIFF
--- a/.agents/docs/environment-variables.md
+++ b/.agents/docs/environment-variables.md
@@ -157,6 +157,9 @@ export WHODB_POSTGRES_1='{
 | `WHODB_ANTHROPIC_API_KEY` | unset | Anthropic API key |
 | `WHODB_ANTHROPIC_ENDPOINT` | `https://api.anthropic.com/v1` | Anthropic API endpoint |
 | `WHODB_ANTHROPIC_NAME` | unset | Display name for Anthropic in the provider dropdown |
+| `WHODB_MINIMAX_API_KEY` | unset | MiniMax API key |
+| `WHODB_MINIMAX_ENDPOINT` | `https://api.minimax.io/v1` | MiniMax API endpoint (set to `https://api.minimaxi.com/v1` for mainland China) |
+| `WHODB_MINIMAX_NAME` | unset | Display name for MiniMax in the provider dropdown |
 
 ### Generic AI providers
 

--- a/core/src/env/env.go
+++ b/core/src/env/env.go
@@ -69,6 +69,10 @@ var LMStudioBaseURL = os.Getenv("WHODB_LMSTUDIO_BASE_URL")
 var LMStudioAPIKey = os.Getenv("WHODB_LMSTUDIO_API_KEY")
 var LMStudioName = os.Getenv("WHODB_LMSTUDIO_NAME")
 
+var MiniMaxAPIKey = os.Getenv("WHODB_MINIMAX_API_KEY")
+var MiniMaxEndpoint = os.Getenv("WHODB_MINIMAX_ENDPOINT")
+var MiniMaxName = os.Getenv("WHODB_MINIMAX_NAME")
+
 var AllowedOrigins = common.FilterList(strings.Split(os.Getenv("WHODB_ALLOWED_ORIGINS"), ","), func(item string) bool {
 	return item != ""
 })
@@ -230,6 +234,16 @@ func GetLMStudioEndpoint() string {
 		return common.ResolveLocalURL(LMStudioBaseURL)
 	}
 	return common.ResolveLocalURL("http://localhost:1234/v1")
+}
+
+// GetMiniMaxEndpoint returns the configured MiniMax base URL, or the default
+// global OpenAI-compatible endpoint if no override is set. Deployments in
+// mainland China can set WHODB_MINIMAX_ENDPOINT to https://api.minimaxi.com/v1.
+func GetMiniMaxEndpoint() string {
+	if MiniMaxEndpoint != "" {
+		return MiniMaxEndpoint
+	}
+	return "https://api.minimax.io/v1"
 }
 
 func getMaxPageSize() int {

--- a/core/src/envconfig/envconfig.go
+++ b/core/src/envconfig/envconfig.go
@@ -300,6 +300,20 @@ func GetConfiguredChatProviders() []env.ChatProvider {
 		})
 	}
 
+	if len(env.MiniMaxAPIKey) > 0 {
+		name := env.MiniMaxName
+		if name == "" {
+			name = "MiniMax"
+		}
+		providers = append(providers, env.ChatProvider{
+			Type:       "MiniMax",
+			Name:       name,
+			APIKey:     env.MiniMaxAPIKey,
+			Endpoint:   env.GetMiniMaxEndpoint(),
+			ProviderId: "minimax-1",
+		})
+	}
+
 	// Flag if legacy OpenAI-Compatible env vars are still set
 	if os.Getenv("WHODB_OPENAI_COMPATIBLE_ENDPOINT") != "" || os.Getenv("WHODB_OPENAI_COMPATIBLE_API_KEY") != "" || os.Getenv("WHODB_CUSTOM_MODELS") != "" {
 		migrate.DeprecatedOpenAICompatibleEnv = true

--- a/core/src/envconfig/envconfig_providers_test.go
+++ b/core/src/envconfig/envconfig_providers_test.go
@@ -137,3 +137,51 @@ func TestGetConfiguredChatProviders(t *testing.T) {
 		t.Fatalf("expected Ollama provider to use overridden host/port, got %+v", providers[3])
 	}
 }
+
+func TestGetConfiguredChatProviders_IncludesMiniMax(t *testing.T) {
+	originalKey := env.MiniMaxAPIKey
+	originalEndpoint := env.MiniMaxEndpoint
+	originalName := env.MiniMaxName
+	t.Cleanup(func() {
+		env.MiniMaxAPIKey = originalKey
+		env.MiniMaxEndpoint = originalEndpoint
+		env.MiniMaxName = originalName
+	})
+
+	env.MiniMaxAPIKey = "minimax-key"
+	env.MiniMaxEndpoint = ""
+	env.MiniMaxName = ""
+
+	var minimax *env.ChatProvider
+	for _, p := range GetConfiguredChatProviders() {
+		if p.Type == "MiniMax" {
+			found := p
+			minimax = &found
+			break
+		}
+	}
+	if minimax == nil {
+		t.Fatalf("expected MiniMax provider to be configured when API key is set")
+	}
+	if minimax.ProviderId != "minimax-1" {
+		t.Fatalf("expected provider id 'minimax-1', got %q", minimax.ProviderId)
+	}
+	if minimax.Name != "MiniMax" {
+		t.Fatalf("expected default name 'MiniMax', got %q", minimax.Name)
+	}
+	if minimax.Endpoint != "https://api.minimax.io/v1" {
+		t.Fatalf("expected default global endpoint, got %q", minimax.Endpoint)
+	}
+}
+
+func TestGetConfiguredChatProviders_OmitsMiniMaxWithoutAPIKey(t *testing.T) {
+	originalKey := env.MiniMaxAPIKey
+	t.Cleanup(func() { env.MiniMaxAPIKey = originalKey })
+
+	env.MiniMaxAPIKey = ""
+	for _, p := range GetConfiguredChatProviders() {
+		if p.Type == "MiniMax" {
+			t.Fatalf("did not expect MiniMax provider when API key is unset")
+		}
+	}
+}

--- a/core/src/llm/llm_client.go
+++ b/core/src/llm/llm_client.go
@@ -30,6 +30,7 @@ func init() {
 	providers.RegisterProvider(providers.NewGeminiProvider())
 	providers.RegisterProvider(providers.NewOllamaProvider())
 	providers.RegisterProvider(providers.NewLMStudioProvider())
+	providers.RegisterProvider(providers.NewMiniMaxProvider())
 
 	// Wire BAML config resolution to use the provider registry
 	bamlconfig.RegisterBAMLConfigResolver(providers.GetBAMLConfig)
@@ -72,6 +73,8 @@ func getEndpointForProvider(providerType providers.LLMType) string {
 		return env.GetOllamaEndpoint()
 	case providers.LMStudio_LLMType:
 		return env.GetLMStudioEndpoint()
+	case providers.MiniMax_LLMType:
+		return env.GetMiniMaxEndpoint()
 	default:
 		// For generic providers, look up endpoint from environment configuration
 		for _, provider := range env.GenericProviders {

--- a/core/src/llm/providers/minimax_provider.go
+++ b/core/src/llm/providers/minimax_provider.go
@@ -16,6 +16,8 @@
 
 package providers
 
+import "strings"
+
 const (
 	MiniMax_LLMType LLMType = "MiniMax"
 )
@@ -25,9 +27,30 @@ const (
 // https://api.minimaxi.com/v1 instead; both regions speak the same protocol.
 const MiniMaxDefaultEndpoint = "https://api.minimax.io/v1"
 
+type MiniMaxProvider struct {
+	*OpenAICompatibleProvider
+}
+
 // NewMiniMaxProvider creates a first-class MiniMax provider backed by the
-// OpenAI-compatible adapter. Models (e.g. MiniMax-M3, MiniMax-M2.7) are
-// discovered from the provider's /models endpoint.
-func NewMiniMaxProvider() *OpenAICompatibleProvider {
-	return NewOpenAICompatibleProvider(MiniMax_LLMType, MiniMaxDefaultEndpoint)
+// OpenAI-compatible adapter.
+func NewMiniMaxProvider() *MiniMaxProvider {
+	return &MiniMaxProvider{
+		OpenAICompatibleProvider: NewOpenAICompatibleProvider(MiniMax_LLMType, MiniMaxDefaultEndpoint),
+	}
+}
+
+// GetSupportedModels filters the shared model catalog to MiniMax chat models.
+func (p *MiniMaxProvider) GetSupportedModels(config *ProviderConfig) ([]string, error) {
+	models, err := p.OpenAICompatibleProvider.GetSupportedModels(config)
+	if err != nil {
+		return nil, err
+	}
+
+	chatModels := make([]string, 0, len(models))
+	for _, model := range models {
+		if strings.HasPrefix(model, "MiniMax-M3") || strings.HasPrefix(model, "MiniMax-M2.7") {
+			chatModels = append(chatModels, model)
+		}
+	}
+	return chatModels, nil
 }

--- a/core/src/llm/providers/minimax_provider.go
+++ b/core/src/llm/providers/minimax_provider.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Clidey, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package providers
+
+const (
+	MiniMax_LLMType LLMType = "MiniMax"
+)
+
+// MiniMaxDefaultEndpoint is the global OpenAI-compatible base URL for MiniMax.
+// Deployments in mainland China can point WHODB_MINIMAX_ENDPOINT at
+// https://api.minimaxi.com/v1 instead; both regions speak the same protocol.
+const MiniMaxDefaultEndpoint = "https://api.minimax.io/v1"
+
+// NewMiniMaxProvider creates a first-class MiniMax provider backed by the
+// OpenAI-compatible adapter. Models (e.g. MiniMax-M3, MiniMax-M2.7) are
+// discovered from the provider's /models endpoint.
+func NewMiniMaxProvider() *OpenAICompatibleProvider {
+	return NewOpenAICompatibleProvider(MiniMax_LLMType, MiniMaxDefaultEndpoint)
+}

--- a/core/src/llm/providers/providers_test.go
+++ b/core/src/llm/providers/providers_test.go
@@ -329,3 +329,54 @@ func TestRedactURL(t *testing.T) {
 		})
 	}
 }
+
+func TestMiniMaxProvider_UsesOpenAICompatibleDefaults(t *testing.T) {
+	provider := NewMiniMaxProvider()
+
+	if provider.GetType() != MiniMax_LLMType {
+		t.Fatalf("expected provider type %q, got %q", MiniMax_LLMType, provider.GetType())
+	}
+	if provider.GetDefaultEndpoint() != MiniMaxDefaultEndpoint {
+		t.Fatalf("expected default endpoint %q, got %q", MiniMaxDefaultEndpoint, provider.GetDefaultEndpoint())
+	}
+
+	clientType, opts, err := provider.CreateBAMLClient(&ProviderConfig{APIKey: "minimax-key"}, "MiniMax-M3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if clientType != "openai-generic" {
+		t.Fatalf("expected client type 'openai-generic', got %q", clientType)
+	}
+	if opts["base_url"] != MiniMaxDefaultEndpoint {
+		t.Fatalf("expected default base_url, got %v", opts["base_url"])
+	}
+	if opts["model"] != "MiniMax-M3" {
+		t.Fatalf("expected model 'MiniMax-M3', got %v", opts["model"])
+	}
+}
+
+func TestMiniMaxProvider_GetSupportedModels_DiscoversFromModelsEndpoint(t *testing.T) {
+	provider := NewMiniMaxProvider()
+	withTestHTTPClient(t, func(r *http.Request) (*http.Response, error) {
+		if r.URL.String() != MiniMaxDefaultEndpoint+"/models" {
+			t.Fatalf("unexpected URL %s", r.URL.String())
+		}
+		if r.Header.Get("Authorization") != "Bearer minimax-key" {
+			t.Fatalf("expected bearer auth header, got %q", r.Header.Get("Authorization"))
+		}
+		return httpResponse(http.StatusOK, `{
+			"data": [
+				{"id": "MiniMax-M3"},
+				{"id": "MiniMax-M2.7"}
+			]
+		}`), nil
+	})
+
+	models, err := provider.GetSupportedModels(&ProviderConfig{APIKey: "minimax-key"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 2 || models[0] != "MiniMax-M3" || models[1] != "MiniMax-M2.7" {
+		t.Fatalf("expected MiniMax chat models, got %#v", models)
+	}
+}

--- a/core/src/llm/providers/providers_test.go
+++ b/core/src/llm/providers/providers_test.go
@@ -367,7 +367,10 @@ func TestMiniMaxProvider_GetSupportedModels_DiscoversFromModelsEndpoint(t *testi
 		return httpResponse(http.StatusOK, `{
 			"data": [
 				{"id": "MiniMax-M3"},
-				{"id": "MiniMax-M2.7"}
+				{"id": "image-01"},
+				{"id": "MiniMax-M2.7"},
+				{"id": "speech-2.8-hd"},
+				{"id": "MiniMax-M3-20260801"}
 			]
 		}`), nil
 	})
@@ -376,7 +379,7 @@ func TestMiniMaxProvider_GetSupportedModels_DiscoversFromModelsEndpoint(t *testi
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(models) != 2 || models[0] != "MiniMax-M3" || models[1] != "MiniMax-M2.7" {
+	if len(models) != 3 || models[0] != "MiniMax-M3" || models[1] != "MiniMax-M2.7" || models[2] != "MiniMax-M3-20260801" {
 		t.Fatalf("expected MiniMax chat models, got %#v", models)
 	}
 }

--- a/frontend/src/config/ai-provider-catalog.ts
+++ b/frontend/src/config/ai-provider-catalog.ts
@@ -29,6 +29,7 @@ const providerCatalog: AIProviderCatalogEntry[] = [
   { id: "OpenAI", label: "OpenAI", iconKey: "OpenAI", status: "available", defaultEndpoint: "https://api.openai.com/v1" },
   { id: "Anthropic", label: "Anthropic", iconKey: "Anthropic", status: "available", defaultEndpoint: "https://api.anthropic.com/v1" },
   { id: "Gemini", label: "Gemini API / AI Studio (API key)", iconKey: "Gemini", status: "available", defaultEndpoint: "https://generativelanguage.googleapis.com/v1beta/openai/" },
+  { id: "MiniMax", label: "MiniMax", status: "available", defaultEndpoint: "https://api.minimax.io/v1" },
   { id: "Ollama", label: "Ollama", iconKey: "Ollama", status: "available", defaultEndpoint: "http://localhost:11434/api" },
   { id: "LMStudio", label: "LM Studio", iconKey: "LMStudio", status: "available", defaultEndpoint: "http://localhost:1234/v1" },
 ];

--- a/frontend/src/store/ai-models.ts
+++ b/frontend/src/store/ai-models.ts
@@ -18,7 +18,7 @@ import type { PayloadAction} from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 
 export const availableInternalModelTypes = ["Ollama"];
-export const availableExternalModelTypes = ["OpenAI", "Anthropic", "Gemini"];
+export const availableExternalModelTypes = ["OpenAI", "Anthropic", "Gemini", "MiniMax"];
 
 export type IAIModelType = {
   id: string;


### PR DESCRIPTION
Reason: WhoDB has no built-in MiniMax provider, so users must configure it manually through the generic OpenAI-compatible adapter with no preset endpoint or model discovery.

## What this does

Registers MiniMax as a first-class, built-in AI chat provider, matching how OpenAI, Anthropic, Gemini, Ollama, and LM Studio are wired.

## Changes

- **`core/src/llm/providers/minimax_provider.go`** (new): defines `MiniMax_LLMType` and `NewMiniMaxProvider()`, backed by the existing `OpenAICompatibleProvider` adapter. The default endpoint is the global OpenAI-compatible base URL `https://api.minimax.io/v1`.
- **`core/src/llm/llm_client.go`**: registers the provider at init and routes its endpoint in `getEndpointForProvider`.
- **`core/src/env/env.go`**: adds `WHODB_MINIMAX_API_KEY` / `WHODB_MINIMAX_ENDPOINT` / `WHODB_MINIMAX_NAME` and a `GetMiniMaxEndpoint()` helper. The endpoint defaults to the global host and can be overridden (for example to the mainland-China host `https://api.minimaxi.com/v1`).
- **`core/src/envconfig/envconfig.go`**: surfaces MiniMax in `GetConfiguredChatProviders()` when an API key is configured, so it appears in the provider list.
- **`frontend/src/store/ai-models.ts`** and **`frontend/src/config/ai-provider-catalog.ts`**: adds MiniMax to the external provider dropdown and catalog with its default endpoint.
- **`.agents/docs/environment-variables.md`**: documents the new environment variables.

Supported models (e.g. `MiniMax-M3`, `MiniMax-M2.7`) are discovered live from the provider's `/models` endpoint, consistent with the other built-in providers.

## Tests

Adds backend tests covering provider registration/defaults, live model discovery from the `/models` endpoint, and environment configuration (present when the API key is set, absent otherwise).

## Checks run

- `go build ./src/llm/... ./src/envconfig/... ./src/env/... ./graph/...`
- `go vet ./src/llm/... ./src/envconfig/... ./src/env/...`
- `go test ./src/llm/... ./src/envconfig/... ./src/env/...` and the graph provider tests — all passing
- `gofmt` clean on all changed Go files

The frontend changes are limited to two additive edits (a string in a list and one catalog entry that conforms to the existing `AIProviderCatalogEntry` type); the repo's pinned frontend toolchain (Node 22 / pnpm 11) was not available in this environment, so the frontend build was not run here.
