### PR TITLE
release

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -103,7 +103,7 @@ parts:
       - GOPATH: "$HOME/go"
       - GOWORK: "$PWD/go.work.desktop-ce"
     build-snaps:
-      - go/latest/stable
+      - go/1.27/stable
     build-packages:
       - gcc
       - g++


### PR DESCRIPTION
* Rename the whodb cli executable from "whodb-cli" to "whodb". "whob-cli" renames as a fallback and will be removed in a future version.
* Update to go 1.27
* Update dependencies throughout
* CLI UI fixes and changes
* Remove broken CLI light theme altogether